### PR TITLE
Fix Visual C++ 2017 compile warnings C4189, C4305, C4661

### DIFF
--- a/hdi/dimensionality_reduction/embedding_equalizer.h
+++ b/hdi/dimensionality_reduction/embedding_equalizer.h
@@ -51,13 +51,6 @@ namespace hdi{
       typedef std::vector<std::unordered_map<uint32_t,uint32_t>> connections_type;
 
     public:
-      class Params{
-      public:
-        Params();
-      };
-
-
-    public:
       EmbeddingEqualizer();
 
       void initialize(data::Embedding<scalar_type>* embedding_master, data::Embedding<scalar_type>* embedding_slave);

--- a/hdi/dimensionality_reduction/embedding_equalizer_inl.h
+++ b/hdi/dimensionality_reduction/embedding_equalizer_inl.h
@@ -51,8 +51,8 @@ namespace hdi{
       _initialized(false),
       _embedding_master(nullptr),
       _embedding_slave(nullptr),
-      _step_size(0.02),
-      _momentum(0.8),
+      _step_size{ static_cast<scalar_type>(0.02) },
+      _momentum{ static_cast<scalar_type>(0.8) },
       _connections(nullptr)
     {
 

--- a/hdi/dimensionality_reduction/gpgpu_sne/gpgpu_sne_compute.cpp
+++ b/hdi/dimensionality_reduction/gpgpu_sne/gpgpu_sne_compute.cpp
@@ -44,7 +44,7 @@ namespace hdi {
     }
 
     Bounds2D GpgpuSneCompute::computeEmbeddingBounds(const embedding_type* embedding, float padding) {
-      const float* points = embedding->getContainer().data();
+      const float* const points = embedding->getContainer().data();
 
       Bounds2D bounds;
       bounds.min.x = std::numeric_limits<float>::max();
@@ -53,8 +53,8 @@ namespace hdi {
       bounds.max.y = -std::numeric_limits<float>::max();
 
       for (int i = 0; i < embedding->numDataPoints(); ++i) {
-        float x = embedding->getContainer().data()[i * 2 + 0];
-        float y = embedding->getContainer().data()[i * 2 + 1];
+        float x = points[i * 2 + 0];
+        float y = points[i * 2 + 1];
 
         bounds.min.x = std::min<float>(x, bounds.min.x);
         bounds.max.x = std::max<float>(x, bounds.max.x);

--- a/hdi/dimensionality_reduction/gpgpu_sne/gpgpu_sne_raster.cpp
+++ b/hdi/dimensionality_reduction/gpgpu_sne/gpgpu_sne_raster.cpp
@@ -34,7 +34,7 @@ namespace hdi {
     }
 
     Bounds2D GpgpuSneRaster::computeEmbeddingBounds(const embedding_type* embedding, float padding) {
-      const float* points = embedding->getContainer().data();
+      const float* const points = embedding->getContainer().data();
 
       Bounds2D bounds;
       bounds.min.x = std::numeric_limits<float>::max();
@@ -43,8 +43,8 @@ namespace hdi {
       bounds.max.y = -std::numeric_limits<float>::max();
 
       for (int i = 0; i < embedding->numDataPoints(); ++i) {
-        float x = embedding->getContainer().data()[i * 2 + 0];
-        float y = embedding->getContainer().data()[i * 2 + 1];
+        float x = points[i * 2 + 0];
+        float y = points[i * 2 + 1];
 
         bounds.min.x = std::min<float>(x, bounds.min.x);
         bounds.max.x = std::max<float>(x, bounds.max.x);

--- a/hdi/dimensionality_reduction/gpgpu_sne/gpgpu_sne_raster.cpp
+++ b/hdi/dimensionality_reduction/gpgpu_sne/gpgpu_sne_raster.cpp
@@ -286,7 +286,7 @@ namespace hdi {
 
       //MAGIC NUMBER
       if (exaggeration > 1.2) {
-        embedding->scaleIfSmallerThan(0.1);
+        embedding->scaleIfSmallerThan(0.1f);
       }
       else {
         embedding->zeroCentered();

--- a/hdi/dimensionality_reduction/gradient_descent_tsne_texture_inl.h
+++ b/hdi/dimensionality_reduction/gradient_descent_tsne_texture_inl.h
@@ -126,7 +126,6 @@ namespace hdi {
       {//Aux data
         _params = params;
         unsigned int size = probabilities.size();
-        unsigned int size_sq = probabilities.size()*probabilities.size();
 
         _embedding = embedding;
         _embedding_container = &(embedding->getContainer());
@@ -164,7 +163,6 @@ namespace hdi {
       {//Aux data
         _params = params;
         unsigned int size = distribution.size();
-        unsigned int size_sq = distribution.size()*distribution.size();
 
         _embedding = embedding;
         _embedding_container = &(embedding->getContainer());

--- a/hdi/dimensionality_reduction/hierarchical_sne_inl.h
+++ b/hdi/dimensionality_reduction/hierarchical_sne_inl.h
@@ -806,7 +806,6 @@ namespace hdi{
               for(auto& v: temp_trans_mat){sum += v.second;}
               for(auto& v: temp_trans_mat){v.second /= sum;}
 
-              auto scale_size = scale.size();
               //removed the threshold depending on the scale -> it makes sense to remove only uneffective neighbors based at every scale -> memory is still under control
               map_helpers_type::initialize(scale._transition_matrix[l],temp_trans_mat.begin(),temp_trans_mat.end(), static_cast<mapped_type>(0.001));
               map_helpers_type::shrinkToFit(scale._transition_matrix[l]);

--- a/hdi/dimensionality_reduction/hierarchical_sne_inl.h
+++ b/hdi/dimensionality_reduction/hierarchical_sne_inl.h
@@ -105,7 +105,7 @@ namespace hdi{
       _mcmcs_walk_length(10),
       _hard_cut_off(false),
       _hard_cut_off_percentage(0.1f),
-      _rs_reduction_factor_per_layer(.1),
+      _rs_reduction_factor_per_layer{ static_cast<scalar_type>(.1) },
       _rs_outliers_removal_jumps(10),
       _num_walks_per_landmark(100),
       _transition_matrix_prune_thresh(1.5),
@@ -808,7 +808,7 @@ namespace hdi{
 
               auto scale_size = scale.size();
               //removed the threshold depending on the scale -> it makes sense to remove only uneffective neighbors based at every scale -> memory is still under control
-              map_helpers_type::initialize(scale._transition_matrix[l],temp_trans_mat.begin(),temp_trans_mat.end(), 0.001);
+              map_helpers_type::initialize(scale._transition_matrix[l],temp_trans_mat.begin(),temp_trans_mat.end(), static_cast<mapped_type>(0.001));
               map_helpers_type::shrinkToFit(scale._transition_matrix[l]);
               progress.step();
             }

--- a/hdi/dimensionality_reduction/sparse_tsne_user_def_probabilities_inl.h
+++ b/hdi/dimensionality_reduction/sparse_tsne_user_def_probabilities_inl.h
@@ -390,7 +390,7 @@ namespace hdi{
 
       //MAGIC NUMBER
       if(exaggerationFactor() > 1.2){
-        _embedding->scaleIfSmallerThan(0.1);
+        _embedding->scaleIfSmallerThan(0.1f);
       }else{
         _embedding->zeroCentered();
       }

--- a/hdi/dimensionality_reduction/sptree.h
+++ b/hdi/dimensionality_reduction/sptree.h
@@ -144,11 +144,9 @@ namespace hdi{
       ~SPTree();
       void setData(scalar_type* inp_data);
       SPTree* getParent();
-      void construct(Cell boundary);
       bool insert(unsigned int new_index);
       void subdivide();
       bool isCorrect();
-      void rebuildTree();
       void getAllIndices(unsigned int* indices);
       unsigned int getDepth();
       void computeNonEdgeForcesOMP(unsigned int point_index, hp_scalar_type theta, hp_scalar_type neg_f[], hp_scalar_type& sum_Q)const;
@@ -164,7 +162,6 @@ namespace hdi{
       void init(SPTree* inp_parent, unsigned int D, scalar_type* inp_data, hp_scalar_type* inp_corner, hp_scalar_type* inp_width);
       void fill(unsigned int N);
       unsigned int getAllIndices(unsigned int* indices, unsigned int loc);
-      bool isChild(unsigned int test_index, unsigned int start, unsigned int end);
     };
 
 

--- a/hdi/dimensionality_reduction/weighted_sptree.h
+++ b/hdi/dimensionality_reduction/weighted_sptree.h
@@ -145,11 +145,9 @@ namespace hdi{
       ~WeightedSPTree();
       void setData(scalar_type* inp_data, const scalar_type* weights);
       WeightedSPTree* getParent();
-      void construct(Cell boundary);
       bool insert(unsigned int new_index);
       void subdivide();
       bool isCorrect();
-      void rebuildTree();
       void getAllIndices(unsigned int* indices);
       unsigned int getDepth();
       void computeNonEdgeForces(unsigned int point_index, hp_scalar_type theta, hp_scalar_type neg_f[], hp_scalar_type& sum_Q)const;
@@ -161,7 +159,6 @@ namespace hdi{
       void init(WeightedSPTree* inp_parent, unsigned int D, scalar_type* inp_data, const scalar_type* weights, hp_scalar_type* inp_corner, hp_scalar_type* inp_width);
       void fill(unsigned int N);
       unsigned int getAllIndices(unsigned int* indices, unsigned int loc);
-      bool isChild(unsigned int test_index, unsigned int start, unsigned int end);
     };
 
 /////////////////////////////////////////////////////////////////

--- a/hdi/utils/math_utils_inl.h
+++ b/hdi/utils/math_utils_inl.h
@@ -265,7 +265,6 @@ namespace hdi{
 
       bool found = false;
       double beta = 1.;
-      double sigma = std::sqrt(1/(2*beta));
       double min_beta = -std::numeric_limits<double>::max();
       double max_beta =  std::numeric_limits<double>::max();
     


### PR DESCRIPTION
Fixed Visual C++ 2017 C4189 warnings (warning level 4), saying:
> dimensionality_reduction\gradient_descent_tsne_texture_inl.h: 'size_sq': local variable is initialized but not referenced
> dimensionality_reduction\gradient_descent_tsne_texture_inl.h: 'size_sq': local variable is initialized but not referenced
> utils\math_utils_inl.h: 'sigma': local variable is initialized but not referenced
> dimensionality_reduction\gpgpu_sne\gpgpu_sne_raster.cpp: 'points': local variable is initialized but not referenced
> dimensionality_reduction\gpgpu_sne\gpgpu_sne_compute.cpp: 'points': local variable is initialized but not referenced
> dimensionality_reduction\hierarchical_sne_inl.h: 'scale_size': local variable is initialized but not referenced

Fixed five Visual C++ 2017 C4305 warnings, saying:
> embedding_equalizer_inl.h: 'initializing': truncation from 'double' to 'scalar_type'
> hierarchical_sne_inl.h: 'initializing': truncation from 'double' to 'float'
> hierarchical_sne_inl.h: 'argument': truncation from 'double' to 'T'
> sparse_tsne_user_def_probabilities_inl.h: 'argument': truncation from 'double' to 'scalar_type'
> gpgpu_sne\gpgpu_sne_raster.cpp: 'argument': truncation from 'double' to 'scalar_type'

Fixed Visual C++ 2017 C4661 warnings, saying:
> embedding_equalizer.h: 'EmbeddingEqualizer::Params::Params(void)': no suitable definition provided for explicit template instantiation request
> sptree.h: 'void SPTree::construct(SPTree::Cell)': no suitable definition provided for explicit template instantiation request
> sptree.h: 'void SPTree::rebuildTree(void)': no suitable definition provided for explicit template instantiation request
> sptree.h: 'bool SPTree::isChild(unsigned int,unsigned int,unsigned int)': no suitable definition provided for explicit template instantiation request
etc.