### PR TITLE
Fix for issue #7.

### DIFF
--- a/hdi/dimensionality_reduction/tsne_inl.h
+++ b/hdi/dimensionality_reduction/tsne_inl.h
@@ -137,7 +137,7 @@ namespace hdi{
         _previous_gradient.resize(size()*params._embedding_dimensionality,0);
         _gain.resize(size()*params._embedding_dimensionality,1);
         _sigmas.resize(size());
-        _init_params = _init_params;
+        _init_params = params;
       }
 
       //compute distances between data-points


### PR DESCRIPTION
In tsne_inl.h in the function void TSNE<scalar_type>::initialize(data::Embedding<scalar_type>* embedding, InitParams params) the member variable '_init_params' was assigned to itself instead of the function parameter 'params' being assinged to '_init_params'.

Bug was found by clang-1100.0.33.8 on macOS