### PR TITLE
Add missing #include <string>

### DIFF
--- a/hdi/data/panel_data.h
+++ b/hdi/data/panel_data.h
@@ -38,6 +38,7 @@
 #include <vector>
 #include <memory>
 #include <map>
+#include <string>
 
 namespace hdi{
   namespace data{


### PR DESCRIPTION
Fixes a VS2019 error:

> hdi/data/panel_data.h(104,1): error C2061: syntax error: identifier 'string'