### PR TITLE
[d2757a3] Allow conan to work with IDE e.g. VS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,25 @@ set(CMAKE_VS_INCLUDE_INSTALL_TO_DEFAULT_BUILD 1)
 
 set(PROJECT "HDILib")
 PROJECT(${PROJECT})
+
+# Disallow in-source builds. 
+# Build in sub dir e.g. source/build* is still allowed!
+if("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}" AND NOT $ENV{CI})
+   message(FATAL_ERROR "In-source builds are not allowed!\n"
+    "Make sure to remove CMakeCache.txt and CMakeFiles/ "
+    "from the source directory!")
+endif()
+
+# This flag is used to allow conan to install the dependencies
+option(HDILIB_BUILD_WITH_CONAN "Should Conan package manager be used?" OFF)
+#The cmake make sub directory contains the ConanSetup.cmake 
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
+  "${PROJECT_SOURCE_DIR}/cmake")
+
+# CONAN is only used for setting up dependencies if the HDILIB_BUILD_WITH_CONAN is ON
+include(ConanSetup)
+message(STATUS "*** (HDI_EXTERNAL_FLANN_INCLUDE_DIR) ${HDI_EXTERNAL_FLANN_INCLUDE_DIR}")
+
 # If the CMAKE_INSTALL_PREFIX has not been set by the user, set it to the build folder
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     message(STATUS "Default CMAKE_INSTALL_PREFIX detected. Setting to build directory.")

--- a/README.md
+++ b/README.md
@@ -68,6 +68,33 @@ make -j 8
 sudo make install
 ```
 
+### Windows build with conan for dependencies
+
+ - In a python (3.6 or 3.7) environment: 
+``` 
+pip install conan
+```
+ - Add the biovault conan remote (for prebuilt packages):
+```
+conan remote add conan-biovault http://cytosplore.lumc.nl:8081/artifactory/api/conan/conan-local
+```
+ - Make a build directory below the HDILib project root. 
+    For example: *./_build_release* or *./_build_debug*
+    (<u>when using conan the source directories are shared but 
+    separate build directories should be used for release and debug.</u>)
+ - In the python environment (with conan and cmake accessible) 
+ cd to the build directory and issue the following (for VisualStudio 2017):
+``` 
+cmake .. -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=Release -DHDILIB_BUILD_WITH_CONAN=ON
+```      
+    (*Note: this assumes that the build dir is one level down from the project root.
+    The default of HDILIB_BUILD_WITH_CONAN is OFF*)
+ - If all goes well Conan will have installed the dependencies in its cache and 
+ created the required defines for the Cmake configuration.
+ Open the .sln in VisualStudio and build ALL_BUILD for Release or Debug matching the CMAKE_BUILD_TYPE.
+     On Windows the result of the build are three *.lib files
+
+
 ## Applications
 
 A suite of command line and visualization applications is available in the [original High Dimensional Inspector](https://github.com/biovault/High-Dimensional-Inspector) repository.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,21 @@ environment:
           CONAN_VISUAL_RUNTIMES: MDd
           BUILD_SHARED: True          
 
+### Limit build to 2019, x64 , Release, Shared
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+          CONAN_VISUAL_VERSIONS: 16
+          CONAN_ARCHS: x86_64
+          CONAN_BUILD_TYPES: Release
+          CONAN_VISUAL_RUNTIMES: MD
+          BUILD_SHARED: True
+          
+### Limit build to 2019, x64 , Debug, Shared
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+          CONAN_VISUAL_VERSIONS: 16
+          CONAN_ARCHS: x86_64
+          CONAN_BUILD_TYPES: Debug
+          CONAN_VISUAL_RUNTIMES: MDd
+          BUILD_SHARED: True       
 install:
   - set PATH=%PYTHON_HOME%;%PYTHON_HOME%/Scripts/;%PATH%
   - pip.exe install conan --upgrade 
@@ -49,9 +64,9 @@ notifications:
     message: "URL is {{buildUrl}} Commit ID {{commitId}}. Messages {{jobs.0.messages.0.message}}"
     on_build_success: true
     on_build_failure: true
-    on_build_status_changed: true     
-        
-test_script:
-  - python build.py
+    on_build_status_changed: true   
+    
+build_script:
+  - cmd: python build.py
   
 after_test:  

--- a/build.py
+++ b/build.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import os
 
 from bincrafters import build_template_default
 from bincrafters import build_shared
@@ -11,6 +12,7 @@ def _is_shared(build):
     
 if __name__ == "__main__":
 
+    print(os.getcwd())
     branch = build_shared.get_repo_branch_from_ci() 
     os.environ["CONAN_HDILIB_CI_BRANCH"] = branch
     builder = build_template_default.get_builder() 

--- a/cmake/ConanSetup.cmake
+++ b/cmake/ConanSetup.cmake
@@ -1,0 +1,89 @@
+if(NOT HDILIB_BUILD_WITH_CONAN)
+    return()
+endif()
+
+message(STATUS "Start ConanSetup")
+
+
+# Build-with-Conan only supports one configuration at a time (per .sln file, for Visual Studio).
+if(CMAKE_BUILD_TYPE AND CMAKE_CONFIGURATION_TYPES)
+    get_property(hdilib_generator_is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+    if(hdilib_generator_is_multi_config)
+        set(CMAKE_CONFIGURATION_TYPES ${CMAKE_BUILD_TYPE})
+    endif()
+endif()
+
+
+# Download the conan cmake macros automatically.
+#This is the location for conan_cmake_run
+if(NOT EXISTS "${CMAKE_BINARY_DIR}/cmake/conan.cmake")
+   message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
+   file(DOWNLOAD "https://github.com/conan-io/cmake-conan/raw/v0.15/conan.cmake"
+                 "${CMAKE_BINARY_DIR}/cmake/conan.cmake")
+endif()
+
+include(${CMAKE_BINARY_DIR}/cmake/conan.cmake)
+
+file(TIMESTAMP ${CMAKE_BINARY_DIR}/conan_install_timestamp.txt file_timestamp "%Y.%m.%d")
+string(TIMESTAMP timestamp "%Y.%m.%d")
+
+# env variable CI exists and is true for Appevor, Travis, CircleCI, GitLab, GitHub Actions
+# on Azure it's TF_BUILD :-(
+if($ENV{CI} or $ENV{TF_BUILD})
+    set(IS_CI TRUE)
+else()
+    set(IS_CI FALSE)
+endif()
+    
+# Run conan install update only once a day
+if("${file_timestamp}" VERSION_LESS ${timestamp} OR IS_CI)
+    file(WRITE ${CMAKE_BINARY_DIR}/conan_install_timestamp.txt "${timestamp}\n")
+    set(CONAN_UPDATE UPDATE)
+    conan_add_remote(NAME conan-hdim INDEX 0 
+        URL http://cytosplore.lumc.nl:8081/artifactory/api/conan/conan-local)
+    conan_add_remote(NAME bincrafters INDEX 1
+        URL https://api.bintray.com/conan/bincrafters/public-conan)
+else()
+    message(STATUS "Conan: Skipping update step.")
+endif()
+
+if(MSVC)
+    set(CC_CACHE $ENV{CC})
+    set(CXX_CACHE $ENV{CXX})
+    unset(ENV{CC}) # Disable clcache, e.g. for building qt
+    unset(ENV{CXX})
+endif()
+
+set(CONAN_SETTINGS "")
+
+if(UNIX)
+    if(LIBCXX) 
+        set(CONAN_SETTINGS ${CONAN_SETTINGS} "compiler.libcxx=${LIBCXX}")
+    endif()    
+endif()
+
+message(STATUS "Install dependencies with conan")
+conan_cmake_run(
+    CONANFILE conanfile.py
+    BASIC_SETUP ${CONAN_UPDATE}
+    BUILD missing
+    BUILD_TYPE ${CMAKE_BUILD_TYPE}
+)
+
+conan_load_buildinfo()
+
+message(STATUS "Installed dependencies with conan")
+set(HDI_LIB_ROOT "${CONAN_HDILIB_ROOT}")
+set(HDI_EXTERNAL_FLANN_INCLUDE_DIR "${CONAN_INCLUDE_DIRS_FLANN}" CACHE PATH "External Flann Include Dir (Required)")
+message(STATUS "Conan Flann include (HDI_EXTERNAL_FLANN_INCLUDE_DIR) ${HDI_EXTERNAL_FLANN_INCLUDE_DIR}")
+if(WIN32)
+    set(FLANN_BUILD_DIR "${CONAN_FLANN_ROOT}")
+    set(GLFW_ROOT "${CONAN_GLFW_ROOT}")
+endif()
+
+if(MSVC)
+    set(ENV{CC} ${CC_CACHE}) # Restore vars
+    set(ENV{CXX} ${CXX_CACHE})
+endif()
+
+message(STATUS "End ConanSetup")

--- a/conanfile.py
+++ b/conanfile.py
@@ -59,7 +59,7 @@ class HDILibConan(ConanFile):
             else: 
                 feat = feat_match.search(ci_branch)
                 if feat is not None:
-                    self.version = "latest_feat_" + feat.group(1)
+                    self.version = feat.group(1)
         self.scm["revision"] = ci_branch            
 
         

--- a/hdi/data/panel_data.h
+++ b/hdi/data/panel_data.h
@@ -38,6 +38,7 @@
 #include <vector>
 #include <memory>
 #include <map>
+#include <string>
 
 namespace hdi{
   namespace data{


### PR DESCRIPTION
Add ConanSetup.cmake to a "Conan light" build style where Conan only provides
the dependencies and the remaining steps can be done using CMake
and your IDE of choice. The requires are still defined in the conanfile.py
but this is loaded by the conan cmake wrapper in the conan_cmake_run