### PR TITLE
fixed an out of range bug that rarely occurs.

### DIFF
--- a/hdi/dimensionality_reduction/hierarchical_sne_inl.h
+++ b/hdi/dimensionality_reduction/hierarchical_sne_inl.h
@@ -463,7 +463,7 @@ namespace hdi {
                     //It could be that the point itself is not the nearest one if two points are identical... I want the point itself to be the first one!
           if (neighborhood_graph[d*nn] != d) {
             int to_swap = d * nn;
-            for (; to_swap < d*nn + nn; ++to_swap) {
+            for (; to_swap < d*nn + (nn-1); ++to_swap) {
               if (neighborhood_graph[to_swap] == d)
                 break;
             }


### PR DESCRIPTION
fixed an out of range bug in the neighborhood_graph that rarely occurs but does cause crashes. The problem is that to_swap can become too large and becomes equal to the size of neighborhood_graph.
