### PR TITLE
Fix build error with gcc

### DIFF
--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -36,7 +36,7 @@ runs:
     - name: Install conan & build configuration
       run: |
         pip install wheel
-        pip install conan~=1.51.0
+        pip install conan>=1.53.0
         pip install "markupsafe<2.1"
         pip install -Iv cmake>=3.17
         if [[ ${{ inputs.conan-build-os }} == "Linux" ]]; then sudo apt-get install -y ninja-build; fi

--- a/.github/conan_windows_build/action.yml
+++ b/.github/conan_windows_build/action.yml
@@ -24,7 +24,7 @@ runs:
     - name: Install conan & build configuration
       run: |
         pip install wheel
-        pip install conan~=1.51.0
+        pip install conan>=1.53.0
         pip install "markupsafe<2.1"
         pip install -Iv cmake>=3.17
         pip install packaging

--- a/hdi/dimensionality_reduction/knn_utils.h
+++ b/hdi/dimensionality_reduction/knn_utils.h
@@ -37,6 +37,7 @@
 #include <string>
 #include <thread>
 #include <mutex>
+#include <atomic>
 
 namespace hdi{
   namespace dr{


### PR DESCRIPTION
I ran into a build error with gcc 11.3 on ubuntu 22.04 which is caused by a missing inclusion