### PR TITLE
Cmake fixes for local build

### DIFF
--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: "g++ clang++"
     required: true
   conan-compiler-version:
-    description: "A number [gcc: 5 6 7 8 9 ] [clang: 39 40 50 60 7 8 9] [10.0]"
+    description: "A number [gcc: 7 8 9 10 11 12] [clang: 39 40 50 60 7 8 9 10 11 12] [10.0]"
     required: true
   conan-libcxx-version:
     description: "Linux: libstdc++ or Macos: libc++ "

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,19 +44,21 @@ jobs:
 
           - name: Linux_gcc11
             os: ubuntu-22.04
+            build-cc: gcc
+            build-cxx: g++
             build-compiler: gcc
             build-cversion: 11
             build-config: Release
             build-os: Linux
             build-libcxx: libstdc++
 
-          - name: Macos_xcode13.4.1
+          - name: Macos_xcode13.4
             os: macos-12
             build-compiler: apple-clang
             build-cversion: 13
             build-config: Release
             build-os: Macos
-            build-xcode-version: 13.4.1
+            build-xcode-version: 13.4
             build-libcxx: libc++
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,11 +28,6 @@ jobs:
     strategy:
       matrix:
         include:
-          #- name: Windows-msvc2017
-          #  os: windows-2016
-          #  compiler: msvc-2017
-          #  build-cversion: 15
-
           # This build is Debug + /analyze flag
           #- name: Static Analysis Windows
           #  os: windows-2019
@@ -55,22 +50,13 @@ jobs:
             build-os: Linux
             build-libcxx: libstdc++
 
-          #- name: Macos_xcode10.3
-          #  os: macos-10.15
-          #  build-compiler: apple-clang
-          #  build-cversion: "10.0"
-          #  build-config: Release
-          #  build-os: Macos
-          #  build-xcode-version: 10.3
-          #  build-libcxx: libc++
-
-          - name: Macos_xcode12.4
-            os: macos-11
+          - name: Macos_xcode14.1
+            os: macos-13
             build-compiler: apple-clang
-            build-cversion: "12.0"
+            build-cversion: "13.0"
             build-config: Release
             build-os: Macos
-            build-xcode-version: 12.4
+            build-xcode-version: 14.1
             build-libcxx: libc++
 
     steps:
@@ -87,7 +73,7 @@ jobs:
       - name: Setup python version
         uses: actions/setup-python@v1
         with:
-          python-version: "3.7"
+          python-version: "3.10"
 
       - name: Setup gcc version
         if: startsWith(matrix.build-compiler, 'gcc')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,13 +50,13 @@ jobs:
             build-os: Linux
             build-libcxx: libstdc++
 
-          - name: Macos_xcode14.1
-            os: macos-13
+          - name: Macos_xcode13.4.1
+            os: macos-12
             build-compiler: apple-clang
             build-cversion: "13.0"
             build-config: Release
             build-os: Macos
-            build-xcode-version: 14.1
+            build-xcode-version: 13.4.1
             build-libcxx: libc++
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,10 +42,10 @@ jobs:
             build-runtime: MD
             build-config: Release
 
-          - name: Linux_gcc9
-            os: ubuntu-20.04
+          - name: Linux_gcc11
+            os: ubuntu-22.04
             build-compiler: gcc
-            build-cversion: 9
+            build-cversion: 11
             build-config: Release
             build-os: Linux
             build-libcxx: libstdc++
@@ -53,7 +53,7 @@ jobs:
           - name: Macos_xcode13.4.1
             os: macos-12
             build-compiler: apple-clang
-            build-cversion: "13.0"
+            build-cversion: 13
             build-config: Release
             build-os: Macos
             build-xcode-version: 13.4.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ message(STATUS "CMAKE_GENERATOR: ${CMAKE_GENERATOR}")
 # -----------------------------------------------------------------------------
 # Dependencies
 # -----------------------------------------------------------------------------
-find_package(lz4 REQUIRED)
+find_package(lz4)
 find_package(flann REQUIRED)
 find_package(OpenMP)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required (VERSION 3.15)
 
-option(USE_AVX "Enable AVX support" OFF)
 option(ENABLE_CODE_ANALYSIS "Use Static Code Analysis on build" OFF)
 
 # Set C++14 language standard
@@ -13,6 +12,7 @@ set(CMAKE_VS_INCLUDE_INSTALL_TO_DEFAULT_BUILD 1)
 set(PROJECT "HDILib")
 PROJECT(${PROJECT})
 
+option(ENABLE_AVX "Enable AVX support" OFF)
 if (ENABLE_CODE_ANALYSIS AND WIN32)
   message("*******Code Analysis Run*******")
 endif()
@@ -40,6 +40,8 @@ endif()
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
   "${PROJECT_SOURCE_DIR}/cmake")
 
+# Test hardware avx capabilities
+include(CMakeSetOptimizationAndAVX)
 
 # If the CMAKE_INSTALL_PREFIX has not been set by the user, set it to the build folder
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ PROJECT(${PROJECT})
 option(ENABLE_AVX "Enable AVX support" OFF)
 option(ENABLE_CODE_ANALYSIS "Use Static Code Analysis on build with MSVC" OFF)
 option(ENABLE_PID "Set POSITION_INDEPENDENT_CODE property for all targets" OFF)
-set(OPTIMIZATION_LEVEL "0" CACHE STRING "Optimization level for all targets in release builds, e.g. 0, 1, 2")
+set(OPTIMIZATION_LEVEL "2" CACHE STRING "Optimization level for all targets in release builds, e.g. 0, 1, 2")
 set(HDILib_VERSION "undefined" CACHE STRING "HDILib Library version")
 
 if (ENABLE_AVX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,25 +1,37 @@
 cmake_minimum_required (VERSION 3.15)
 
-option(ENABLE_CODE_ANALYSIS "Use Static Code Analysis on build" OFF)
+set(PROJECT "HDILib")
+PROJECT(${PROJECT})
 
-# Set C++14 language standard
+# -----------------------------------------------------------------------------
+# User Options
+# -----------------------------------------------------------------------------
+option(ENABLE_AVX "Enable AVX support" OFF)
+option(ENABLE_CODE_ANALYSIS "Use Static Code Analysis on build with MSVC" OFF)
+option(ENABLE_PID "Set POSITION_INDEPENDENT_CODE property for all targets" OFF)
+set(OPTIMIZATION_LEVEL "0" CACHE STRING "Optimization level for all targets in release builds, e.g. 0, 1, 2")
+set(HDILib_VERSION "undefined" CACHE STRING "HDILib Library version")
+
+if (ENABLE_AVX)
+    message("ENABLE_AVX is ON")
+endif()
+
+if (ENABLE_CODE_ANALYSIS AND WIN32)
+    message("Code Analysis ENABLED")
+endif()
+
+if (ENABLE_PID)
+    message(STATUS "Position independent code compilation ON")
+endif()
+
+# -----------------------------------------------------------------------------
+# CMake Options
+# -----------------------------------------------------------------------------
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Enable the INSTALL project for building by default in VS
 set(CMAKE_VS_INCLUDE_INSTALL_TO_DEFAULT_BUILD 1)
-
-set(PROJECT "HDILib")
-PROJECT(${PROJECT})
-
-option(ENABLE_AVX "Enable AVX support" OFF)
-if (ENABLE_CODE_ANALYSIS AND WIN32)
-  message("*******Code Analysis Run*******")
-endif()
-
-if (ENABLE_PID)
-  message(STATUS "Position independent code code compilation ON")
-endif()
 
 if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DWIN32 /EHsc /MP /permissive- /Zc:__cplusplus")
@@ -27,7 +39,6 @@ if(MSVC)
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
 endif(MSVC)
 
-set(HDILib_VERSION "undefined" CACHE STRING "HDILib Library version")
 # Disallow in-source builds. 
 # Build in sub dir e.g. source/build* is still allowed!
 if("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}" AND NOT $ENV{CI})
@@ -36,7 +47,7 @@ if("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}" AND NOT $ENV{CI})
     "from the source directory!")
 endif()
 
-#The cmake make sub directory contains the ConanSetup.cmake 
+#The cmake make sub directory contains the i.a. ConanSetup.cmake 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
   "${PROJECT_SOURCE_DIR}/cmake")
 
@@ -58,24 +69,32 @@ endif()
 
 message(STATUS "CMAKE_GENERATOR: ${CMAKE_GENERATOR}")
 
+# -----------------------------------------------------------------------------
+# Dependencies
+# -----------------------------------------------------------------------------
 find_package(lz4 REQUIRED)
 find_package(flann REQUIRED)
 find_package(OpenMP)
 
 if(OpenMP_CXX_FOUND)
-	message (STATUS "OpenMP found")
+    message (STATUS "OpenMP found")
 elseif(CMAKE_GENERATOR STREQUAL Xcode)
-	add_definitions( -D__USE_GCD__)
+    add_definitions( -D__USE_GCD__)
 else()
     message(WARNING, "OpenMP not found!")
 endif()
 
+# -----------------------------------------------------------------------------
+# Projects
+# -----------------------------------------------------------------------------
 add_subdirectory (hdi/utils)
 add_subdirectory (hdi/data)
 add_subdirectory (hdi/dimensionality_reduction)
 
+# -----------------------------------------------------------------------------
+# Create HDILib find_package
+# -----------------------------------------------------------------------------
 # NOTE CMake installs are defined in the sub-projects.
-# ***Create a HdpsCore package to support the find_package command**
 
 # Helper macro for packaging
 include(CMakePackageConfigHelpers)
@@ -86,8 +105,6 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/ConfigVersion.cmake.in "${CMAKE
 #write_basic_package_version_file(
 #  "${CMAKE_CURRENT_BINARY_DIR}/HDILibConfigVersion.cmake"
 #  VERSION "${HDILib_VERSION}"
-#  # When the hdps core is stable compatibility can 
-#  # change to AnyNewerVersion or SameMajorVersion
 #  COMPATIBILITY ExactVersion
 #)
 

--- a/README.md
+++ b/README.md
@@ -85,17 +85,17 @@ cmake -S . -B build -G "Visual Studio 16 2019" -A "x64" -DCMAKE_TOOLCHAIN_FILE=.
 ```
 
 **Linux**
-This will produce a Makefile. Use the make command e.g. *make -j 8* to build. 
+This will produce a Makefile, other generators like ninja are also possible. Use the make command e.g. *make -j 8* to build. 
 gcc8 or gcc9 should be used for prebuilt flann
 
 ```bash
-cmake  -S . -B -DCMAKE_BUILD_TYPE=Release -DINSTALL_PREBUILT_DEPENDENCIES=ON -DCMAKE_INSTALL_PREFIX=install -G "Unix Makefiles"
+cmake  -S . -B -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -G "Unix Makefiles"
 ```
 
 **Macos**
-Use Xcode 10.3 apple-clang 10 is supported
+Tested with Xcode 10.3 & apple-clang 10:
 ```bash
-cmake  -S . -B -DCMAKE_BUILD_TYPE=Release -DINSTALL_PREBUILT_DEPENDENCIES=ON -DCMAKE_INSTALL_PREFIX=install
+cmake  -S . -B -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install
 ```
 
 ## Using the HDILib

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ brew install flann
 This will produce a HDILib.sln file for VisualStudio. 
 Open the .sln in VisualStudio and build ALL_BUILD for Release or Debug matching the CMAKE_BUILD_TYPE.
 ```cmd
-cmake -S . -B build -G "Visual Studio 16 2019" -A "x64" -DCMAKE_TOOLCHAIN_FILE=.\build\conan_toolchain.cmake -DCMAKE_INSTALL_PREFIX=install
+cmake -S . -B build -G "Visual Studio 16 2019" -A "x64" -DCMAKE_TOOLCHAIN_FILE=.\build\conan_toolchain.cmake -DVCPKG_TARGET_TRIPLET=x64-windows-static -DCMAKE_INSTALL_PREFIX=install
 ```
 
 **Linux**

--- a/README.md
+++ b/README.md
@@ -85,11 +85,13 @@ cmake -S . -B build -G "Visual Studio 16 2019" -A "x64" -DCMAKE_TOOLCHAIN_FILE=.
 ```
 
 **Linux**
-This will produce a Makefile, other generators like ninja are also possible. Use the make command e.g. *make -j 8* to build. 
-gcc8 or gcc9 should be used for prebuilt flann
+This will produce a Makefile, other generators like ninja are also possible. Use the make commands e.g. `make -j 8 && make install` to build and install. 
 
 ```bash
 cmake  -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -DENABLE_PID=ON -G "Unix Makefiles"
+
+// build and install the libary, independent of generator
+cmake --build build --config Release --target install
 ```
 
 **Macos**

--- a/README.md
+++ b/README.md
@@ -67,12 +67,12 @@ When configuring cmake make sure to setup vcpkg with CMAKE_TOOLCHAIN_FILE (`PATH
 
 On Linux with e.g.
 ```bash
-sudo apt-get -y install libflann-dev
+sudo apt-get -y install libflann-dev liblz4-dev
 ```
 
 On Mac OS with
 ```
-brew install flann
+brew install flann lz4
 ```
 
 ### Generate the build files
@@ -89,13 +89,13 @@ This will produce a Makefile, other generators like ninja are also possible. Use
 gcc8 or gcc9 should be used for prebuilt flann
 
 ```bash
-cmake  -S . -B -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -G "Unix Makefiles"
+cmake  -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -DENABLE_PID=ON -G "Unix Makefiles"
 ```
 
 **Macos**
 Tested with Xcode 10.3 & apple-clang 10:
 ```bash
-cmake  -S . -B -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install
+cmake  -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install
 ```
 
 ## Using the HDILib

--- a/cmake/CMakeSetOptimizationAndAVX.cmake
+++ b/cmake/CMakeSetOptimizationAndAVX.cmake
@@ -2,7 +2,7 @@
 # Check for and link to AVX instruction sets
 # -----------------------------------------------------------------------------
 macro(check_and_set_AVX target useavx)
-    message(STATUS "Set instruction sets for ${target}, MV_USE_AVX is ${useavx}")
+    message(STATUS "Set instruction sets for ${target}, USE_AVX is ${useavx}")
 
     if(${useavx})
         # Use cmake hardware checks to see whether AVX should be activated
@@ -21,10 +21,10 @@ macro(check_and_set_AVX target useavx)
             check_cxx_compiler_flag(${AXV2_CompileOption} COMPILER_OPT_AVX2_SUPPORTED)
         endif()
 
-        if(COMPILER_OPT_AVX2_SUPPORTED)
+        if(${COMPILER_OPT_AVX2_SUPPORTED} AND ${ARGC} EQUAL 2)
             message( STATUS "Use AXV2 for ${target}")
             target_compile_options(${target} PRIVATE ${AXV2_CompileOption})
-        elseif(COMPILER_OPT_AVX_SUPPORTED)
+        elseif(${COMPILER_OPT_AVX_SUPPORTED})
             message( STATUS "Use AXV for ${target}")
             target_compile_options(${target} PRIVATE ${AXV_CompileOption})
         endif()

--- a/cmake/CMakeSetOptimizationAndAVX.cmake
+++ b/cmake/CMakeSetOptimizationAndAVX.cmake
@@ -1,6 +1,10 @@
 # -----------------------------------------------------------------------------
 # Check for and link to AVX instruction sets
 # -----------------------------------------------------------------------------
+# usage: 
+#  check_and_set_AVX(${TARGET} ${USE_AVX})
+#  check_and_set_AVX(${TARGET} ${USE_AVX} 1)    # optional argument, only use AVX (not AVX2 even if available)
+
 macro(check_and_set_AVX target useavx)
     message(STATUS "Set instruction sets for ${target}, USE_AVX is ${useavx}")
 

--- a/cmake/CMakeSetOptimizationAndAVX.cmake
+++ b/cmake/CMakeSetOptimizationAndAVX.cmake
@@ -37,13 +37,14 @@ endmacro()
 macro(set_optimization_level target level)
     message(STATUS "Set optimization level in release for ${target} to ${level}")
 
-    # Check compiler being used
     if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
-        # Set optimization flags for GCC and Clang
         set(OPTIMIZATION_LEVEL_FLAG "-O${level}")
     elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-        # Set optimization flags for MSVC
-        set(OPTIMIZATION_LEVEL_FLAG "/O${level}")
+        if(${level} EQUAL 0)
+            set(OPTIMIZATION_LEVEL_FLAG "/Od")
+        else()
+            set(OPTIMIZATION_LEVEL_FLAG "/O${level}")
+        endif()
     endif()
 
     target_compile_options(${target} PRIVATE "$<$<CONFIG:Release>:${OPTIMIZATION_LEVEL_FLAG}>")

--- a/cmake/CMakeSetOptimizationAndAVX.cmake
+++ b/cmake/CMakeSetOptimizationAndAVX.cmake
@@ -1,0 +1,52 @@
+# -----------------------------------------------------------------------------
+# Check for and link to AVX instruction sets
+# -----------------------------------------------------------------------------
+macro(check_and_set_AVX target useavx)
+    message(STATUS "Set instruction sets for ${target}, MV_USE_AVX is ${useavx}")
+
+    if(${useavx})
+        # Use cmake hardware checks to see whether AVX should be activated
+        include(CheckCXXCompilerFlag)
+
+        if(MSVC)
+            set(AXV_CompileOption "/arch:AVX")
+            set(AXV2_CompileOption "/arch:AVX2")
+        else()
+            set(AXV_CompileOption "-DUSE_AVX")
+            set(AXV2_CompileOption "-DUSE_AVX2")
+        endif()
+        
+        if(NOT DEFINED COMPILER_OPT_AVX_SUPPORTED OR NOT DEFINED COMPILER_OPT_AVX2_SUPPORTED)
+            check_cxx_compiler_flag(${AXV_CompileOption} COMPILER_OPT_AVX_SUPPORTED)
+            check_cxx_compiler_flag(${AXV2_CompileOption} COMPILER_OPT_AVX2_SUPPORTED)
+        endif()
+
+        if(COMPILER_OPT_AVX2_SUPPORTED)
+            message( STATUS "Use AXV2 for ${target}")
+            target_compile_options(${target} PRIVATE ${AXV2_CompileOption})
+        elseif(COMPILER_OPT_AVX_SUPPORTED)
+            message( STATUS "Use AXV for ${target}")
+            target_compile_options(${target} PRIVATE ${AXV_CompileOption})
+        endif()
+    endif()
+endmacro()
+
+# -----------------------------------------------------------------------------
+# Sets the optimization level
+# -----------------------------------------------------------------------------
+macro(set_optimization_level target level)
+    message(STATUS "Set optimization level in release for ${target} to ${level}")
+
+    # Check compiler being used
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
+        # Set optimization flags for GCC and Clang
+        set(OPTIMIZATION_LEVEL_FLAG "-O${level}")
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        # Set optimization flags for MSVC
+        set(OPTIMIZATION_LEVEL_FLAG "/O${level}")
+    endif()
+
+    target_compile_options(${target} PRIVATE "$<$<CONFIG:Release>:${OPTIMIZATION_LEVEL_FLAG}>")
+
+    message( STATUS "Optimization level for ${target} (release) is ${OPTIMIZATION_LEVEL_FLAG}")
+endmacro()

--- a/hdi/data/CMakeLists.txt
+++ b/hdi/data/CMakeLists.txt
@@ -16,10 +16,6 @@ if(OpenMP_CXX_FOUND)
     target_link_libraries(${PROJECT} PRIVATE OpenMP::OpenMP_CXX)
 endif()
 
-if(ENABLE_CODE_ANALYSIS AND WIN32)
-    target_compile_options(${PROJECT} PRIVATE /analyze)
-endif()
-
 if(ENABLE_PID)
     set_target_properties(${PROJECT} PROPERTIES POSITION_INDEPENDENT_CODE ON)
 endif()
@@ -30,7 +26,9 @@ if(ENABLE_CODE_ANALYSIS)
     endif()
 endif()
 
+set_optimization_level(${PROJECT} ${OPTIMIZATION_LEVEL})
 check_and_set_AVX(${PROJECT} ${ENABLE_AVX})
+
 ########### INSTALL ##############
 install(TARGETS ${PROJECT}
     EXPORT ${PROJECT}Targets

--- a/hdi/data/CMakeLists.txt
+++ b/hdi/data/CMakeLists.txt
@@ -30,6 +30,7 @@ if(ENABLE_CODE_ANALYSIS)
     endif()
 endif()
 
+check_and_set_AVX(${PROJECT} ${ENABLE_AVX})
 ########### INSTALL ##############
 install(TARGETS ${PROJECT}
     EXPORT ${PROJECT}Targets

--- a/hdi/dimensionality_reduction/CMakeLists.txt
+++ b/hdi/dimensionality_reduction/CMakeLists.txt
@@ -79,10 +79,15 @@ install(CODE "foreach(DR_HEADER ${HeaderFiles})
 
 # Install dependency headers
 if(NOT DEFINED ENV{CI})
-    if(DEFINED flann_INCLUDE_DIR AND DEFINED lz4_INCLUDE_DIR)
+    if(DEFINED flann_INCLUDE_DIR)
         install(DIRECTORY "${flann_INCLUDE_DIR}/" DESTINATION "${CMAKE_INSTALL_PREFIX}/include" COMPONENT FLANN_HEADERS)
+    endif()
+
+    if(DEFINED lz4_INCLUDE_DIR)
         install(DIRECTORY "${lz4_INCLUDE_DIR}/" DESTINATION "${CMAKE_INSTALL_PREFIX}/include" COMPONENT LZ4_HEADERS)
-    elseif(DEFINED VCPKG_INSTALLED_DIR)
+    endif()
+    
+    if(DEFINED VCPKG_INSTALLED_DIR)
         install(DIRECTORY "${VCPKG_INSTALLED_DIR}/x64-windows-static/include/flann/" DESTINATION "${CMAKE_INSTALL_PREFIX}/include/flann/" COMPONENT FLANN_HEADERS)
         install(CODE "foreach(LZ4_HEADER lz4.h lz4file.h lz4frame.h lz4frame_static.h lz4hc.h)
                 execute_process(

--- a/hdi/dimensionality_reduction/CMakeLists.txt
+++ b/hdi/dimensionality_reduction/CMakeLists.txt
@@ -80,8 +80,21 @@ install(CODE "foreach(DR_HEADER ${HeaderFiles})
 
 # Install dependency headers
 if(NOT DEFINED ENV{CI})
-    install(DIRECTORY "${flann_INCLUDE_DIR}/" DESTINATION "${CMAKE_INSTALL_PREFIX}/include" COMPONENT FLANN_HEADERS)
-    install(DIRECTORY "${lz4_INCLUDE_DIR}/" DESTINATION "${CMAKE_INSTALL_PREFIX}/include" COMPONENT LZ4_HEADERS)
+    if(DEFINED flann_INCLUDE_DIR AND DEFINED lz4_INCLUDE_DIR)
+        install(DIRECTORY "${flann_INCLUDE_DIR}/" DESTINATION "${CMAKE_INSTALL_PREFIX}/include" COMPONENT FLANN_HEADERS)
+        install(DIRECTORY "${lz4_INCLUDE_DIR}/" DESTINATION "${CMAKE_INSTALL_PREFIX}/include" COMPONENT LZ4_HEADERS)
+    elseif(DEFINED VCPKG_INSTALLED_DIR)
+        install(DIRECTORY "${VCPKG_INSTALLED_DIR}/x64-windows-static/include/flann/" DESTINATION "${CMAKE_INSTALL_PREFIX}/include/flann/" COMPONENT FLANN_HEADERS)
+        install(CODE "foreach(LZ4_HEADER lz4.h lz4file.h lz4frame.h lz4frame_static.h lz4hc.h)
+                execute_process(
+                    COMMAND \"${CMAKE_COMMAND}\" -E copy_if_different 
+                        \"${VCPKG_INSTALLED_DIR}/x64-windows-static/include/\${LZ4_HEADER}\" 
+                        \"${CMAKE_INSTALL_PREFIX}/include/\${LZ4_HEADER}\"
+                )
+            endforeach()"
+            COMPONENT ANNOY_HEADERS
+        )
+    endif()
 endif()
 
 install(DIRECTORY "${HNSWLIB_INCLUDE_DIR}/hnswlib/" DESTINATION "${CMAKE_INSTALL_PREFIX}/include/hnswlib" COMPONENT HNSW_HEADERS)

--- a/hdi/dimensionality_reduction/CMakeLists.txt
+++ b/hdi/dimensionality_reduction/CMakeLists.txt
@@ -34,26 +34,24 @@ if(OpenMP_CXX_FOUND)
     target_link_libraries(${PROJECT} PRIVATE OpenMP::OpenMP_CXX)
 endif()
 
+if(ENABLE_PID)
+    set_target_properties(${PROJECT} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+endif()
+
 if(ENABLE_CODE_ANALYSIS)
     if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
         target_compile_options(${PROJECT} PRIVATE /analyze)
     endif()
 endif()
 
+set_optimization_level(${PROJECT} ${OPTIMIZATION_LEVEL})
 check_and_set_AVX(${PROJECT} ${ENABLE_AVX})
+
 if(UNIX)
     set(THREADS_PREFER_PTHREAD_FLAG ON)
     find_package(Threads REQUIRED)
     target_link_libraries(${PROJECT} PRIVATE Threads::Threads)
 endif(UNIX)
-
-if(ENABLE_CODE_ANALYSIS AND WIN32)
-    target_compile_options(${PROJECT} PRIVATE /analyze)
-endif()
-
-if(ENABLE_PID)
-    set_target_properties(${PROJECT} PROPERTIES POSITION_INDEPENDENT_CODE ON)
-endif()
 
 ########### INSTALL ##############
 #set_target_properties(${PROJECT} PROPERTIES PUBLIC_HEADER "${HeaderFiles}")

--- a/hdi/dimensionality_reduction/CMakeLists.txt
+++ b/hdi/dimensionality_reduction/CMakeLists.txt
@@ -40,6 +40,7 @@ if(ENABLE_CODE_ANALYSIS)
     endif()
 endif()
 
+check_and_set_AVX(${PROJECT} ${ENABLE_AVX})
 if(UNIX)
     set(THREADS_PREFER_PTHREAD_FLAG ON)
     find_package(Threads REQUIRED)

--- a/hdi/dimensionality_reduction/CMakeLists.txt
+++ b/hdi/dimensionality_reduction/CMakeLists.txt
@@ -67,7 +67,7 @@ install(TARGETS ${PROJECT}
 # Preserve the header hierarchy by explicit install
 # the CMake PUBLIC_HEADER target property flattens it if used.
 install(CODE "foreach(DR_HEADER ${HeaderFiles})
-        message(STATUS \"Installing: \${HEADER} to \${CMAKE_INSTALL_PREFIX}/include/hdi/dimensionality_reduction\")
+        message(STATUS \"Installing: \${DR_HEADER} to \${CMAKE_INSTALL_PREFIX}/include/hdi/dimensionality_reduction\")
         execute_process(
             COMMAND \"${CMAKE_COMMAND}\" -E copy_if_different 
                 \"${CMAKE_CURRENT_SOURCE_DIR}/\${DR_HEADER}\" 

--- a/hdi/utils/CMakeLists.txt
+++ b/hdi/utils/CMakeLists.txt
@@ -14,24 +14,22 @@ if(OpenMP_CXX_FOUND)
     target_link_libraries(${PROJECT} PRIVATE OpenMP::OpenMP_CXX)
 endif()
 
+if(ENABLE_PID)
+    set_target_properties(${PROJECT} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+endif()
+
 if(ENABLE_CODE_ANALYSIS)
     if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
         target_compile_options(${PROJECT} PRIVATE /analyze)
     endif()
 endif()
 
+set_optimization_level(${PROJECT} ${OPTIMIZATION_LEVEL})
 check_and_set_AVX(${PROJECT} ${ENABLE_AVX})
+
 if (UNIX)
     target_link_libraries (hdiutils PRIVATE ${CMAKE_DL_LIBS}) # glad.cpp requires -ldl
 endif (UNIX)
-
-if(ENABLE_CODE_ANALYSIS AND WIN32)
-        target_compile_options(${PROJECT} PRIVATE /analyze)
-endif()
-
-if(ENABLE_PID)
-    set_target_properties(${PROJECT} PROPERTIES POSITION_INDEPENDENT_CODE ON)
-endif()
 
 ########### INSTALL ##############
 install(TARGETS ${PROJECT}

--- a/hdi/utils/CMakeLists.txt
+++ b/hdi/utils/CMakeLists.txt
@@ -20,6 +20,7 @@ if(ENABLE_CODE_ANALYSIS)
     endif()
 endif()
 
+check_and_set_AVX(${PROJECT} ${ENABLE_AVX})
 if (UNIX)
     target_link_libraries (hdiutils PRIVATE ${CMAKE_DL_LIBS}) # glad.cpp requires -ldl
 endif (UNIX)


### PR DESCRIPTION
- Improve: Add option to set optimization level for all targets in release build
- Fix: actually set avx (previously there was an option, but it did nothing)
- Fix: headers were installed twice when dependencies are set up with vcpkg
- Fix: clarify vcpkg static cmake setting in README
- Fix: some clearer cmake structure
- CI: upgrade MacOS from 11 to 12 and XCode from 12.4 to 13.4
- CI: upgrade Ubuntu from 20.04 to 22.04. A new LTS version will be out soon, which means that 20.04 will be deprecated soon as well
- CI: upgrade Python from 3.7 to 3.10 since the older version is not supported anymore for newer MacOS versions