### PR TITLE
More uniform API and initial embedding fixes

### DIFF
--- a/hdi/dimensionality_reduction/sparse_tsne_user_def_probabilities.h
+++ b/hdi/dimensionality_reduction/sparse_tsne_user_def_probabilities.h
@@ -69,7 +69,9 @@ namespace hdi{
       void reset();
       //! Reset the class and remove all the data points
       void clear();
-      
+
+      //! Wheter initialization flag is true
+      bool isInitialized() { return _initialized == true; }
 
       //! Get the position in the embedding for a data point
       void getEmbeddingPosition(scalar_vector_type& embedding_position, data_handle_type handle)const;

--- a/hdi/dimensionality_reduction/sparse_tsne_user_def_probabilities_inl.h
+++ b/hdi/dimensionality_reduction/sparse_tsne_user_def_probabilities_inl.h
@@ -123,7 +123,10 @@ namespace hdi{
       utils::secureLogValue(_logger,"Number of data points",_P.size());
 
       computeHighDimensionalDistribution(probabilities);
-      initializeEmbeddingPosition(params._seed, params._rngRange);
+
+      if (!params._presetEmbedding) {
+        initializeEmbeddingPosition(_params._seed, _params._rngRange);
+      }
 
       _iteration = 0;
 
@@ -152,7 +155,10 @@ namespace hdi{
       utils::secureLogValue(_logger,"Number of data points",_P.size());
 
       _P = distribution;
-      initializeEmbeddingPosition(params._seed, params._rngRange);
+
+      if (!params._presetEmbedding) {
+        initializeEmbeddingPosition(_params._seed, _params._rngRange);
+      }
 
       _iteration = 0;
 

--- a/hdi/dimensionality_reduction/tsne.h
+++ b/hdi/dimensionality_reduction/tsne.h
@@ -72,6 +72,7 @@ namespace hdi{
         double _mom_switching_iter;
         double _exaggeration_factor;
         int _remove_exaggeration_iter;
+        bool _presetEmbedding;
       };
 
 
@@ -94,6 +95,9 @@ namespace hdi{
       void clear();
       //! Return the number of data points
       int size(){  return static_cast<int>(_high_dimensional_data.size());  }
+
+      //! Wheter initialization flag is true
+      bool isInitialized() { return _initialized == true; }
 
       //! Get the dimensionality of the data
       int dimensionality(){return _dimensionality;}

--- a/hdi/dimensionality_reduction/tsne_inl.h
+++ b/hdi/dimensionality_reduction/tsne_inl.h
@@ -61,7 +61,8 @@ namespace hdi{
       _final_momentum(0.8),
       _mom_switching_iter(250),
       _exaggeration_factor(4),
-      _remove_exaggeration_iter(250)
+      _remove_exaggeration_iter(250),
+      _presetEmbedding(false)
     {}
 
   /////////////////////////////////////////////////////////////////////////
@@ -143,13 +144,14 @@ namespace hdi{
       //compute distances between data-points
       computeHighDimensionalDistances();
       //Compute gaussian distributions
-      computeGaussianDistributions(params._perplexity);
+      computeGaussianDistributions(_init_params._perplexity);
       //Compute High-dimensional distribution
       computeHighDimensionalDistribution();
 
-
       //Initialize Embedding position
-      initializeEmbeddingPosition(params._seed);
+      if (!_init_params._presetEmbedding) {
+        initializeEmbeddingPosition(_init_params._seed);
+      }
 
       _iteration = 0;
 

--- a/hdi/dimensionality_reduction/tsne_parameters.h
+++ b/hdi/dimensionality_reduction/tsne_parameters.h
@@ -65,7 +65,7 @@ namespace hdi {
       double _exaggeration_factor;                //! exaggeration factor for the attractive forces. Note: it shouldn't be too high when few points are used
       unsigned int _remove_exaggeration_iter;     //! iterations with complete exaggeration of the attractive forces
       unsigned int _exponential_decay_iter;       //! iterations required to remove the exaggeration using an exponential decay
-      bool _presetEmbedding;					  //! Used at initialization to use the input embedding positions 
+      bool _presetEmbedding;					            //! Used at initialization to use the input embedding positions 
     };
   }
 }

--- a/hdi/dimensionality_reduction/wtsne.h
+++ b/hdi/dimensionality_reduction/wtsne.h
@@ -41,6 +41,7 @@
 #include <unordered_map>
 #include "hdi/data/embedding.h"
 #include "hdi/data/map_mem_eff.h"
+#include "tsne_parameters.h"
 
 namespace hdi{
   namespace dr{
@@ -58,36 +59,18 @@ namespace hdi{
       typedef uint32_t data_handle_type;
 
     public:
-      //! Parameters used for the initialization of the algorithm
-      class Parameters{
-      public:
-        Parameters();
-        int _seed;
-        int _embedding_dimensionality;
-
-        double _minimum_gain;
-        double _eta;                //! constant multiplicator of the gradient
-        double _momentum;
-        double _final_momentum;
-        double _mom_switching_iter;         //! momentum switching iteration
-        double _exaggeration_factor;        //! exaggeration factor for the attractive forces. Note: it shouldn't be too high when few points are used
-        unsigned int _remove_exaggeration_iter;   //! iterations with complete exaggeration of the attractive forces
-        unsigned int _exponential_decay_iter;     //! iterations required to remove the exaggeration using an exponential decay
-      };
-
-
-    public:
       WeightedTSNE();
       //! Initialize the class with a list of distributions. A joint-probability distribution will be computed as in the tSNE algorithm
-      void initialize(const sparse_scalar_matrix& probabilities, data::Embedding<scalar_type>* embedding, Parameters params = Parameters());
+      void initialize(const sparse_scalar_matrix& probabilities, data::Embedding<scalar_type>* embedding, TsneParameters params = Parameters());
       //! Initialize the class with a joint-probability distribution. Note that it must be provided non initialized and with the weight of each row equal to 2.
-      void initializeWithJointProbabilityDistribution(const sparse_scalar_matrix& distribution, data::Embedding<scalar_type>* embedding, Parameters params = Parameters());
+      void initializeWithJointProbabilityDistribution(const sparse_scalar_matrix& distribution, data::Embedding<scalar_type>* embedding, TsneParameters params = TsneParameters());
       //! Reset the internal state of the class but it keeps the inserted data-points
       void reset();
       //! Reset the class and remove all the data points
       void clear();
 
-
+      bool isInitialized() { return _initialized == true; }
+      
       //! Get the position in the embedding for a data point
       void getEmbeddingPosition(scalar_vector_type& embedding_position, data_handle_type handle)const;
 
@@ -141,8 +124,6 @@ namespace hdi{
       //! Compute the exaggeration factor based on the current iteration
       scalar_type exaggerationFactor();
 
-
-
     private:
       data::Embedding<scalar_type>* _embedding; //! embedding
       typename data::Embedding<scalar_type>::scalar_vector_type* _embedding_container;
@@ -159,7 +140,7 @@ namespace hdi{
       scalar_vector_type _gain; //! Gain
       scalar_type _theta; //! value of theta used in the Barnes-Hut approximation. If a value of 1 is provided the exact tSNE computation is used.
 
-      Parameters _params;
+      TsneParameters _params;
       unsigned int _iteration;
 
       utils::AbstractLog* _logger;

--- a/hdi/dimensionality_reduction/wtsne.h
+++ b/hdi/dimensionality_reduction/wtsne.h
@@ -61,7 +61,7 @@ namespace hdi{
     public:
       WeightedTSNE();
       //! Initialize the class with a list of distributions. A joint-probability distribution will be computed as in the tSNE algorithm
-      void initialize(const sparse_scalar_matrix& probabilities, data::Embedding<scalar_type>* embedding, TsneParameters params = Parameters());
+      void initialize(const sparse_scalar_matrix& probabilities, data::Embedding<scalar_type>* embedding, TsneParameters params = TsneParameters());
       //! Initialize the class with a joint-probability distribution. Note that it must be provided non initialized and with the weight of each row equal to 2.
       void initializeWithJointProbabilityDistribution(const sparse_scalar_matrix& distribution, data::Embedding<scalar_type>* embedding, TsneParameters params = TsneParameters());
       //! Reset the internal state of the class but it keeps the inserted data-points


### PR DESCRIPTION
- Each t-SNE class should have a `isInitialized()` member
- Each t-SNE class should check if a preset initial embedding is set before randomly initializing (same fix as f97954da8ee9eb08e83ed56a7421c37d9ab6eea1 but now for the other classes, too)
- `WeightedTSNE` used it's own parameter class that was identical to the `TsneParameters` class