### PR TITLE
Use MacOS 15 instead of 12 on CI 

### DIFF
--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: "g++ clang++"
     required: true
   conan-compiler-version:
-    description: "A number [gcc: 8 9 10 11 12 13] [clang: 39 40 50 60 7 8 9 10 11 12 13] [10.0]"
+    description: "A number [gcc: 8 9 10 11 12 13 14 15] [clang: 39 40 50 60 7 8 9 10 11 12 13 14 15 16 177 18 19 20] [10.0]"
     required: true
   conan-libcxx-version:
     description: "Linux: libstdc++ or Macos: libc++ "

--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -39,7 +39,7 @@ runs:
     - name: Install conan & build configuration
       run: |
         pip install wheel
-        pip install conan==1.64.0
+        pip install conan==1.66.0
         pip install "markupsafe<2.1"
         pip install -Iv cmake>=3.17
         if [[ ${{ inputs.conan-build-os }} == "Linux" ]]; then sudo apt-get install -y ninja-build; fi

--- a/.github/conan_windows_build/action.yml
+++ b/.github/conan_windows_build/action.yml
@@ -27,7 +27,7 @@ runs:
     - name: Install conan & build configuration
       run: |
         pip install wheel
-        pip install conan==1.64.0
+        pip install conan==1.66.0
         pip install "markupsafe<2.1"
         pip install -Iv cmake>=3.17
         pip install packaging

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
             build-cversion: 16
             build-config: Release
             build-os: Macos
-            build-xcode-version: 16.2
+            build-xcode-version: 16
             build-libcxx: libc++
             build-arch: armv8
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,16 +71,6 @@ jobs:
             build-libcxx: libstdc++11
             build-arch: x86_64
 
-          - name: Macos_xcode13.4
-            os: macos-12
-            build-compiler: apple-clang
-            build-cversion: 13
-            build-config: Release
-            build-os: Macos
-            build-xcode-version: 13.4
-            build-libcxx: libc++
-            build-arch: x86_64
-
           - name: Macos_xcode14.3
             os: macos-13
             build-compiler: apple-clang
@@ -101,9 +91,19 @@ jobs:
             build-libcxx: libc++
             build-arch: armv8
 
+          - name: Macos_xcode16
+            os: macos-15
+            build-compiler: apple-clang
+            build-cversion: 16
+            build-config: Release
+            build-os: Macos
+            build-xcode-version: 16.2
+            build-libcxx: libc++
+            build-arch: armv8
+
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -113,7 +113,7 @@ jobs:
           sudo xcode-select -switch /Applications/Xcode_${{matrix.build-xcode-version}}.app
 
       - name: Setup python version
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -8,7 +8,7 @@ import sys
 from packaging import version
 from pathlib import Path
 
-required_conan_version = "~=1.64.0"
+required_conan_version = "~=1.66.0"
 
 
 class HDILibConan(ConanFile):

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -5,7 +5,7 @@ from conans import ConanFile, tools
 from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps
 import shutil
 
-required_conan_version = "~=1.64.0"
+required_conan_version = "~=1.66.0"
 
 # This is a "hello world" type test that checks that the conan package can be consumed
 # i.e. that that cmake support works, consumption of HDILib headers (compiler) and lib (linker) works


### PR DESCRIPTION
See https://github.com/actions/runner-images/issues/10721
> The macOS 12 Actions runner image will begin deprecation on 10/7/24 and will be fully unsupported by 12/3/24 for GitHub and by 01/13/25 for ADO

Also: update conan to [1.66 which adds new apple-clang 16](https://github.com/conan-io/conan/releases/tag/1.66.0)