### PR TITLE
Update CI 02 2025 

### DIFF
--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -38,12 +38,12 @@ runs:
   steps:
     - name: Install conan & build configuration
       run: |
-        pip install wheel
-        pip install conan==1.66.0
-        pip install "markupsafe<2.1"
-        pip install -Iv cmake>=3.17
-        if [[ ${{ inputs.conan-build-os }} == "Linux" ]]; then sudo apt-get install -y ninja-build; fi
+        pip install conan~=1.66.0
         pip install packaging
+
+        if [[ ${{ inputs.conan-build-os }} == "Linux" ]]; then 
+          sudo apt-get install -y ninja-build; 
+        fi
 
         export CONAN_CMAKE_PROGRAM=`which cmake`
         echo CMake version:

--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -3,7 +3,7 @@ description: "Encapsulate cmake composite run steps that are common for Linux an
 # reference https://docs.github.com/en/free-pro-team@latest/actions/creating-actions/creating-a-composite-run-steps-action
 inputs:
   conan-compiler:
-    description: "gcc9 apple-clang"
+    description: "gcc apple-clang"
     required: true
   conan-cc:
     description: "gcc clang"
@@ -12,7 +12,7 @@ inputs:
     description: "g++ clang++"
     required: true
   conan-compiler-version:
-    description: "A number [gcc: 8 9 10 11 12 13] [clang: 39 40 50 60 7 8 9 10 11 12 13] [10.0]"
+    description: "A number [gcc: 5 6 7 8 9 10 11 12 13 14] [clang: 39 40 50 60 7 8 9 10 11 12 13 14 15 16 17 18 19 20] [10.0]"
     required: true
   conan-libcxx-version:
     description: "Linux: libstdc++ or Macos: libc++ "

--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -39,7 +39,7 @@ runs:
     - name: Install conan & build configuration
       run: |
         pip install wheel
-        pip install conan==1.64.0
+        pip install conan==1.66.0
         pip install "markupsafe<2.1"
         pip install -Iv cmake>=3.17
         if [[ ${{ inputs.conan-build-os }} == "Linux" ]]; then sudo apt-get install -y ninja-build; fi

--- a/.github/conan_windows_build/action.yml
+++ b/.github/conan_windows_build/action.yml
@@ -27,7 +27,7 @@ runs:
     - name: Install conan & build configuration
       run: |
         pip install wheel
-        pip install conan==1.64.0
+        pip install conan==1.66.0
         pip install "markupsafe<2.1"
         pip install -Iv cmake>=3.17
         pip install packaging

--- a/.github/conan_windows_build/action.yml
+++ b/.github/conan_windows_build/action.yml
@@ -3,7 +3,7 @@ description: "Encapsulate cmake composite run steps that are common for Windows,
 # reference https://docs.github.com/en/free-pro-team@latest/actions/creating-actions/creating-a-composite-run-steps-action
 inputs:
   conan-visual-version:
-    description: "MSVC version: 15, 16 represent msvc-2017 or msvc-2019"
+    description:"MSVC version: 16, 17 represent msvc-2019 and msvc-2022"
     required: true
   conan-build-type:
     description: "Empty or Analysis"

--- a/.github/conan_windows_build/action.yml
+++ b/.github/conan_windows_build/action.yml
@@ -57,7 +57,6 @@ runs:
       run: |
         for /f "delims=" %%i in ('where cmake') do set CONAN_CMAKE_PROGRAM="%%i"
         set CONAN_USER_HOME=%cd%\_conan
-        set VS160COMNTOOLS="C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools"
 
         echo Add LKEB artifactory as remote at URL: %CONAN_UPLOAD%
         conan remote add %CONAN_LKEB_ARTIFACTORY% %CONAN_UPLOAD%

--- a/.github/conan_windows_build/action.yml
+++ b/.github/conan_windows_build/action.yml
@@ -26,10 +26,7 @@ runs:
   steps:
     - name: Install conan & build configuration
       run: |
-        pip install wheel
-        pip install conan==1.66.0
-        pip install "markupsafe<2.1"
-        pip install -Iv cmake>=3.17
+        pip install conan~=1.66.0
         pip install packaging
 
         REM Fish the package name from the conanfile.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
           sudo xcode-select -switch /Applications/Xcode_${{matrix.build-xcode-version}}.app
 
       - name: Setup python version
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,14 +51,6 @@ jobs:
             build-config: Release
             build-arch: x86_64
 
-          - name: Windows-msvc2025
-            os: windows-2025
-            compiler: msvc-2022
-            build-cversion: 17
-            build-runtime: MD
-            build-config: Release
-            build-arch: x86_64
-
           - name: Linux_gcc11
             os: ubuntu-22.04
             build-cc: gcc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,13 +119,6 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Setup gcc version
-        if: startsWith(matrix.build-compiler, 'gcc')
-        uses: egor-tensin/setup-gcc@v1
-        with:
-          version: ${{matrix.build-cversion}}
-          platform: x64
-
       - name: Windows build
         if: startsWith(runner.os, 'Windows')
         uses: ./.github/conan_windows_build
@@ -137,7 +130,7 @@ jobs:
           conan-password: ${{secrets.LKEB_ARTIFACTORY_PASSWORD}}
           hdilib-cdash-token: ${{secrets.HDILIB_TOKEN}}
 
-      - name: Linux Mac build
+      - name: Linux build
         if: startsWith(runner.os, 'ubuntu')
         uses: ./.github/conan_linuxmac_build
         with:
@@ -150,7 +143,7 @@ jobs:
           conan-user: ${{secrets.LKEB_ARTIFACTORY_USER}}
           conan-password: ${{secrets.LKEB_ARTIFACTORY_PASSWORD}}
 
-      - name: Linux Mac build
+      - name: Mac build
         if: startsWith(runner.os, 'macOS')
         uses: ./.github/conan_linuxmac_build
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,13 +51,12 @@ jobs:
             build-config: Release
             build-arch: x86_64
 
-          - name: Linux_gcc10
-            os: ubuntu-20.04
-            build-compiler: gcc
-            build-cversion: 10
+          - name: Windows-msvc2025
+            os: windows-2025
+            compiler: msvc-2022
+            build-cversion: 17
+            build-runtime: MD
             build-config: Release
-            build-os: Linux
-            build-libcxx: libstdc++11
             build-arch: x86_64
 
           - name: Linux_gcc11
@@ -71,14 +70,15 @@ jobs:
             build-libcxx: libstdc++11
             build-arch: x86_64
 
-          - name: Macos_xcode13.4
-            os: macos-12
-            build-compiler: apple-clang
+          - name: Linux_gcc13
+            os: ubuntu-24.04
+            build-cc: gcc
+            build-cxx: g++
+            build-compiler: gcc
             build-cversion: 13
             build-config: Release
-            build-os: Macos
-            build-xcode-version: 13.4
-            build-libcxx: libc++
+            build-os: Linux
+            build-libcxx: libstdc++11
             build-arch: x86_64
 
           - name: Macos_xcode14.3
@@ -103,7 +103,7 @@ jobs:
 
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -136,7 +136,20 @@ jobs:
           hdilib-cdash-token: ${{secrets.HDILIB_TOKEN}}
 
       - name: Linux Mac build
-        if: "!startsWith(runner.os, 'Windows')"
+        if: startsWith(runner.os, 'ubuntu')
+        uses: ./.github/conan_linuxmac_build
+        with:
+          conan-compiler: ${{matrix.build-compiler}}
+          conan-compiler-version: ${{matrix.build-cversion}}
+          conan-libcxx-version: ${{matrix.build-libcxx}}
+          conan-build-type: ${{matrix.build-config}}
+          conan-build-os: ${{matrix.build-os}}
+          build-arch: ${{matrix.build-arch}}
+          conan-user: ${{secrets.LKEB_ARTIFACTORY_USER}}
+          conan-password: ${{secrets.LKEB_ARTIFACTORY_PASSWORD}}
+
+      - name: Linux Mac build
+        if: startsWith(runner.os, 'macOS')
         uses: ./.github/conan_linuxmac_build
         with:
           conan-compiler: ${{matrix.build-compiler}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,16 @@ jobs:
             build-libcxx: libc++
             build-arch: armv8
 
+          - name: Macos_xcode16
+            os: macos-15
+            build-compiler: apple-clang
+            build-cversion: 16
+            build-config: Release
+            build-os: Macos
+            build-xcode-version: 16.2
+            build-libcxx: libc++
+            build-arch: armv8
+
     steps:
       - name: Checkout the source
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
           python-version: "3.11"
 
       - name: Windows build
-        if: startsWith(runner.os, 'Windows')
+        if: startsWith(matrix.os, 'Windows')
         uses: ./.github/conan_windows_build
         with:
           conan-visual-version: ${{matrix.build-cversion}}
@@ -131,7 +131,7 @@ jobs:
           hdilib-cdash-token: ${{secrets.HDILIB_TOKEN}}
 
       - name: Linux build
-        if: startsWith(runner.os, 'ubuntu')
+        if: startsWith(matrix.os, 'ubuntu')
         uses: ./.github/conan_linuxmac_build
         with:
           conan-compiler: ${{matrix.build-compiler}}
@@ -144,7 +144,7 @@ jobs:
           conan-password: ${{secrets.LKEB_ARTIFACTORY_PASSWORD}}
 
       - name: Mac build
-        if: startsWith(runner.os, 'macOS')
+        if: startsWith(matrix.os, 'macOS')
         uses: ./.github/conan_linuxmac_build
         with:
           conan-compiler: ${{matrix.build-compiler}}

--- a/conanfile.py
+++ b/conanfile.py
@@ -7,6 +7,7 @@ import os
 import sys
 from packaging import version
 from pathlib import Path
+import subprocess
 
 required_conan_version = "~=1.66.0"
 
@@ -90,6 +91,12 @@ class HDILibConan(ConanFile):
             self.deps_cpp_info["lz4"].rootpath, "lib", "cmake"
         ).as_posix()
         tc.variables["IN_CONAN_BUILD"] = "TRUE"
+
+        if os_info.is_macos:
+            proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)
+            omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
+            tc.variables["OpenMP_ROOT"] = omp_prefix_path
+
         print("Call toolchain generate")
         tc.generate()
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -123,6 +123,10 @@ class HDILibConan(ConanFile):
             cmake_release.build(build_type="Release")
             cmake_release.install(build_type="Release")
 
+            cmake_release = self._configure_cmake()
+            cmake_release.build(build_type="RelWithDebInfo")
+            cmake_release.install(build_type="RelWithDebInfo")
+
     def package_id(self):
         # The package contains both Debug and Release build types
         del self.info.settings.build_type
@@ -141,3 +145,4 @@ class HDILibConan(ConanFile):
         # (*.pdb) if building the Visual Studio version
         if self.settings.compiler == "Visual Studio":
             self.copy("*.pdb", dst="lib/Debug", keep_path=False)
+            self.copy("*.pdb", dst="lib/RelWithDebInfo", keep_path=False)

--- a/conanfile.py
+++ b/conanfile.py
@@ -8,7 +8,7 @@ import sys
 from packaging import version
 from pathlib import Path
 
-required_conan_version = "~=1.64.0"
+required_conan_version = "~=1.66.0"
 
 
 class HDILibConan(ConanFile):

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -3,7 +3,9 @@ import platform
 from pathlib import Path
 from conans import ConanFile, tools
 from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps
+from conans.tools import os_info
 import shutil
+import subprocess
 
 required_conan_version = "~=1.66.0"
 

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -35,6 +35,12 @@ class HDILibTestConan(ConanFile):
         tc.variables["lz4_ROOT"] = Path(
             self.deps_cpp_info["lz4"].rootpath, "lib", "cmake"
         ).as_posix()
+
+        if os_info.is_macos:
+            proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)
+            omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
+            tc.variables["OpenMP_ROOT"] = omp_prefix_path
+
         tc.generate()
 
     def requirements(self):

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -5,7 +5,7 @@ from conans import ConanFile, tools
 from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps
 import shutil
 
-required_conan_version = "~=1.64.0"
+required_conan_version = "~=1.66.0"
 
 # This is a "hello world" type test that checks that the conan package can be consumed
 # i.e. that that cmake support works, consumption of HDILib headers (compiler) and lib (linker) works


### PR DESCRIPTION
- Remove `ubuntu-20.04`
- Remove `macos-12`
- Add `ubuntu-24.04`
- Add `macos-15` (XCode 16.2, ARM)
- Add `RelWithDebInfo` build

See https://github.com/actions/runner-images/issues/10721
> The macOS 12 Actions runner image will begin deprecation on 10/7/24 and will be fully unsupported by 12/3/24 for GitHub and by 01/13/25 for ADO

See https://github.com/actions/runner-images/issues/11101
> The Ubuntu 20.04 Actions runner image will begin deprecation on 2025-02-01 and will be fully unsupported by 2025-04-01 

Also: 
- Update conan to [1.66 which adds new apple-clang 16](https://github.com/conan-io/conan/releases/tag/1.66.0) (Otherwise adding `macos-15` (XCode 16.2) won't compile)
  - **Caution**: I think this will require downstream repos (i.e. t-SNE analysis plugins from ManiVault) to also upgrade their conan version
- Do not install and use CMake with Python. This majorly interferes with finding and `OpenMP` and Apple's ARM platforms

Depends on https://github.com/biovault/conan-lz4/pull/1 and https://github.com/biovault/conan-flann/pull/2