### PR TITLE
Extract nptsne build update from 1.2.10 branch

### DIFF
--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -100,9 +100,9 @@ runs:
         export HOMEBREW_NO_AUTO_UPDATE=1
         export CONAN_PACKAGE_VERSION=`conan inspect --raw version conanfile.py`
         if [[ ${{ inputs.conan-build-os }} == "Macos" ]] && [[ ${{ inputs.conan-compiler-version }} == "14" ]]; then
-          conan create . HDILib/$biovault/${{ inputs.conan-channel }} -pr:h action_build -pr:b action_build -pr compatibility -s build_type=Release -o HDILib:shared=False -o HDILib:fPIC=True
+          conan create . HDILib/$CONAN_PACKAGE_VERSION@biovault/${{ inputs.conan-channel }} -pr:h action_build -pr:b action_build -pr compatibility -s build_type=Release -o HDILib:shared=False -o HDILib:fPIC=True
         else
-          conan create . HDILib/$biovault/${{ inputs.conan-channel }} -pr:h action_build -pr:b action_build -s build_type=Release -o HDILib:shared=False -o HDILib:fPIC=True
+          conan create . HDILib/$CONAN_PACKAGE_VERSION@biovault/${{ inputs.conan-channel }} -pr:h action_build -pr:b action_build -s build_type=Release -o HDILib:shared=False -o HDILib:fPIC=True
         fi
 
       shell: bash

--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -23,6 +23,10 @@ inputs:
   conan-build-os:
     description: "Linux or Macos"
     required: true
+  conan-channel:
+    description: "The reference channel one of [stable python]"
+    default: "stable" # Default value for input2
+    required: false
   build-arch:
     description: "either x86_64 or armv8 (for macos)"
     required: true
@@ -38,11 +42,22 @@ runs:
   steps:
     - name: Install conan & build configuration
       run: |
-        pip install conan~=1.66.0
-        pip install packaging
+        pip3 install conan~=1.66.0
+        pip3 install packaging
 
-        if [[ ${{ inputs.conan-build-os }} == "Linux" ]]; then 
-          sudo apt-get install -y ninja-build; 
+        if [[ ${{ inputs.conan-build-os }} == "Linux" ]]; then
+          if [[ ${{ inputs.conan-channel }} == "python" ]]; then 
+            dnf install -y ninja-build;
+            yum install -y libomp;
+          else
+            sudo apt-get install -y ninja-build;
+          fi
+        fi
+
+        if [[ ${{ inputs.conan-build-os }} == "Linux" ]] && [[ ${{ inputs.conan-compiler-version }} == "10" ]]; then
+          sudo apt install gcc-10 g++-10 libstdc++-10-dev
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10 --slave /usr/bin/gcov gcov /usr/bin/gcov-10
+          sudo update-alternatives --set gcc /usr/bin/gcc-10
         fi
 
         export CONAN_CMAKE_PROGRAM=`which cmake`
@@ -85,9 +100,9 @@ runs:
         export HOMEBREW_NO_AUTO_UPDATE=1
         export CONAN_PACKAGE_VERSION=`conan inspect --raw version conanfile.py`
         if [[ ${{ inputs.conan-build-os }} == "Macos" ]] && [[ ${{ inputs.conan-compiler-version }} == "14" ]]; then
-          conan create . HDILib/$CONAN_PACKAGE_VERSION@biovault/stable -pr:h action_build -pr:b action_build -pr compatibility -s build_type=Release -o HDILib:shared=False -o HDILib:fPIC=True
+          conan create . HDILib/$biovault/${{ inputs.conan-channel }} -pr:h action_build -pr:b action_build -pr compatibility -s build_type=Release -o HDILib:shared=False -o HDILib:fPIC=True
         else
-          conan create . HDILib/$CONAN_PACKAGE_VERSION@biovault/stable -pr:h action_build -pr:b action_build -s build_type=Release -o HDILib:shared=False -o HDILib:fPIC=True
+          conan create . HDILib/$biovault/${{ inputs.conan-channel }} -pr:h action_build -pr:b action_build -s build_type=Release -o HDILib:shared=False -o HDILib:fPIC=True
         fi
 
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,17 @@ jobs:
             build-config: Release
             build-arch: x86_64
 
+          - name: Linux_gcc10
+            os: ubuntu-22.04
+            build-cc: gcc
+            build-cxx: g++
+            build-compiler: gcc
+            build-cversion: 10
+            build-config: Release
+            build-os: Linux
+            build-libcxx: libstdc++11
+            build-arch: x86_64
+
           - name: Linux_gcc11
             os: ubuntu-22.04
             build-cc: gcc
@@ -64,6 +75,27 @@ jobs:
             build-os: Linux
             build-libcxx: libstdc++11
             build-arch: x86_64
+
+          - name: Linux_gcc14
+            os: ubuntu-24.04
+            build-cc: gcc
+            build-cxx: g++
+            build-compiler: gcc
+            build-cversion: 14
+            build-config: Release
+            build-os: Linux
+            build-libcxx: libstdc++11
+            build-arch: x86_64
+
+          - name: Macos_xcode14.3
+            os: macos-14
+            build-compiler: apple-clang
+            build-cversion: 14
+            build-config: Release
+            build-os: Macos
+            build-xcode-version: 15.0.1
+            build-libcxx: libc++
+            build-arch: armv8
 
           - name: Macos_xcode15
             os: macos-14

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,3 +169,49 @@ jobs:
           build-arch: ${{matrix.build-arch}}
           conan-user: ${{secrets.LKEB_ARTIFACTORY_USER}}
           conan-password: ${{secrets.LKEB_ARTIFACTORY_PASSWORD}}
+
+  Python-ManyLinux-2-28-Build:
+    runs-on: ubuntu-latest
+    container: quay.io/pypa/manylinux_2_28_x86_64
+    strategy:
+      matrix:
+        include: 
+          - name: python manylinux_2_28
+            build-cc: gcc
+            build-cxx: g++
+            build-compiler: gcc
+            build-cversion: 14
+            build-config: Release
+            build-os: Linux
+            build-libcxx: libstdc++11
+            build-arch: x86_64      
+
+    steps:
+      - name: Checkout the source
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Verify default Python installation
+        run: |
+          python3 --version
+          python3 -m ensurepip --upgrade
+          pip3 --version
+  
+      - name: Verify Python installation
+        run: |
+          python3 --version
+          pip3 --version
+      - name: Linux build
+        uses: ./.github/conan_linuxmac_build
+        with:
+          conan-compiler: ${{matrix.build-compiler}}
+          conan-compiler-version: ${{matrix.build-cversion}}
+          conan-libcxx-version: ${{matrix.build-libcxx}}
+          conan-build-type: ${{matrix.build-config}}
+          conan-build-os: ${{matrix.build-os}}
+          conan-channel: python
+          build-arch: ${{matrix.build-arch}}
+          conan-user: ${{secrets.LKEB_ARTIFACTORY_USER}}
+          conan-password: ${{secrets.LKEB_ARTIFACTORY_PASSWORD}}
+  

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,11 @@ message(STATUS "CMAKE_GENERATOR: ${CMAKE_GENERATOR}")
 # -----------------------------------------------------------------------------
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(CMAKE_C_STANDARD 17)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
 
 # Enable the INSTALL project for building by default in VS
 set(CMAKE_VS_INCLUDE_INSTALL_TO_DEFAULT_BUILD 1)

--- a/conanfile.py
+++ b/conanfile.py
@@ -26,7 +26,7 @@ class HDILibConan(ConanFile):
     default_channel = "stable"
 
     # Options may need to change depending on the packaged library
-    settings = "os", "compiler", "arch", "build_type", "channel"
+    settings = "os", "compiler", "arch", "build_type"
     # Note : This should only be built with: shared=False, fPIC=True
     options = {"shared": [True, False], "fPIC": [True, False]}
     default_options = {"shared": False, "fPIC": True}
@@ -57,7 +57,7 @@ class HDILibConan(ConanFile):
             del self.options.fPIC
 
     def generate(self):
-        print("In generate")
+        print(f"Generate for channel {self.channel}")
         generator = None
         if self.settings.os == "Macos":
             generator = "Xcode"
@@ -95,8 +95,8 @@ class HDILibConan(ConanFile):
         tc.variables["IN_CONAN_BUILD"] = "TRUE"
 
         # Fix build with manylinux for nptsne building
-        if self.settings.os == "Linux" and self.settings.channel == "python":
-            print(f"self.settings.channel: {self.settings.channel}")
+        if self.settings.os == "Linux" and self.channel == "python":
+            print(f"self.settings.channel: {self.channel}")
             tc.variables["CMAKE_C_FLAGS"] = (
                 "${CMAKE_C_FLAGS} -m64 -std=c99 -D_ISOC99_SOURCE -D_GNU_SOURCE"
             )

--- a/conanfile.py
+++ b/conanfile.py
@@ -96,6 +96,7 @@ class HDILibConan(ConanFile):
 
         # Fix build with manylinux for nptsne building
         if self.settings.os == "Linux" and self.settings.channel == "python":
+            print(f"self.settings.channel: {self.settings.channel}")
             tc.variables["CMAKE_C_FLAGS"] = (
                 "${CMAKE_C_FLAGS} -m64 -std=c99 -D_ISOC99_SOURCE -D_GNU_SOURCE"
             )

--- a/conanfile.py
+++ b/conanfile.py
@@ -96,7 +96,6 @@ class HDILibConan(ConanFile):
 
         # Fix build with manylinux for nptsne building
         if self.settings.os == "Linux" and self.channel == "python":
-            print(f"self.settings.channel: {self.channel}")
             tc.variables["CMAKE_C_FLAGS"] = (
                 "${CMAKE_C_FLAGS} -m64 -std=c99 -D_ISOC99_SOURCE -D_GNU_SOURCE"
             )

--- a/conanfile.py
+++ b/conanfile.py
@@ -94,6 +94,13 @@ class HDILibConan(ConanFile):
         ).as_posix()
         tc.variables["IN_CONAN_BUILD"] = "TRUE"
 
+        # Fix build with manylinux for nptsne building
+        if self.settings.os == "Linux" and self.settings.compiler.version == "14":
+            tc.variables["CMAKE_C_FLAGS"] = (
+                "${CMAKE_C_FLAGS} -m64 -std=c99 -D_ISOC99_SOURCE -D_GNU_SOURCE"
+            )
+            tc.variables["CMAKE_CXX_FLAGS"] = "${CMAKE_CXX_FLAGS} -D_ISOC99_SOURCE"
+
         if os_info.is_macos:
             proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)
             omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"

--- a/conanfile.py
+++ b/conanfile.py
@@ -19,7 +19,9 @@ class HDILibConan(ConanFile):
     topics = ("embedding", "analysis", "n-dimensional", "tSNE")
     url = "https://github.com/biovault/HDILib"
     author = "B. van Lew <b.van_lew@lumc.nl>"  # conanfile author
-    license = "MIT"  # License for packaged library; please use SPDX Identifiers https://spdx.org/licenses/
+    license = (  # License for packaged library; please use SPDX Identifiers https://spdx.org/licenses/
+        "MIT"
+    )
     default_user = "lkeb"
     default_channel = "stable"
 
@@ -108,7 +110,8 @@ class HDILibConan(ConanFile):
 
     def build(self):
         print(
-            f"Build folder {self.build_folder} \n Package folder {self.package_folder}\n Source folder {self.source_folder}"
+            f"Build folder {self.build_folder} \n Package folder"
+            f" {self.package_folder}\n Source folder {self.source_folder}"
         )
         install_dir = Path(self.build_folder).joinpath("install")
         install_dir.mkdir(exist_ok=True)

--- a/conanfile.py
+++ b/conanfile.py
@@ -95,7 +95,7 @@ class HDILibConan(ConanFile):
         tc.variables["IN_CONAN_BUILD"] = "TRUE"
 
         # Fix build with manylinux for nptsne building
-        if self.settings.os == "Linux" and self.settings.compiler.version == "14":
+        if self.settings.os == "Linux" and self.settings.channel == "python":
             tc.variables["CMAKE_C_FLAGS"] = (
                 "${CMAKE_C_FLAGS} -m64 -std=c99 -D_ISOC99_SOURCE -D_GNU_SOURCE"
             )

--- a/conanfile.py
+++ b/conanfile.py
@@ -26,7 +26,7 @@ class HDILibConan(ConanFile):
     default_channel = "stable"
 
     # Options may need to change depending on the packaged library
-    settings = "os", "compiler", "arch", "build_type"
+    settings = "os", "compiler", "arch", "build_type", "channel"
     # Note : This should only be built with: shared=False, fPIC=True
     options = {"shared": [True, False], "fPIC": [True, False]}
     default_options = {"shared": False, "fPIC": True}

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -60,8 +60,8 @@ class HDILibTestConan(ConanFile):
             return
         if tools.os_info.is_linux:
             installer = tools.SystemPackageTool()
-            installer.install("libomp5")
-            installer.install("libomp-dev")
+            #installer.install("libomp5")
+            #installer.install("libomp-dev")
 
     def build(self):
         if os.getenv("Analysis", None) is not None:


### PR DESCRIPTION
- Explicitly set C standard for all targets
- Test on more CI runners
- Add manylinux fixes/workarounds from [the 1.2.10 branch](https://github.com/biovault/HDILib/tree/release/1.2.10) as figured out by @bldrvnlw 