### PR TITLE
Explicit cmake sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ ci/
 install
 out
 hdi/dimensionality_reduction/dr_config.h
+hdi/dimensionality_reduction/gpgpu_vulkan/shaders/*.hpp

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ ci/
 *.bak
 install
 out
-*.hpp
+hdi/dimensionality_reduction/dr_config.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,7 +171,10 @@ endif()
 message(STATUS "annoy at ${Annoy_SOURCE_DIR}")
 
 if (USE_VULKAN_KOMPUTE)
-    # Neede for fmt library used in vulkan 
+    find_package(fmt CONFIG REQUIRED)
+    find_package(kompute CONFIG REQUIRED)
+
+    # Needed for fmt library used in vulkan 
     add_compile_options("$<$<C_COMPILER_ID:MSVC>:/utf-8>")
     add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
 endif()

--- a/hdi/data/CMakeLists.txt
+++ b/hdi/data/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(PROJECT "hdidata")
+set(PROJECT_DATA "hdidata")
 
 set(HeaderFilesData
     abstract_data.h
@@ -32,45 +32,45 @@ set(SourceFilesData
     shader.cpp
 )
 
-add_library(${PROJECT} STATIC ${HeaderFilesData} ${SourceFilesData} )
+add_library(${PROJECT_DATA} STATIC ${HeaderFilesData} ${SourceFilesData} )
 
-target_include_directories(${PROJECT} PRIVATE "${PROJECT_SOURCE_DIR}")
+target_include_directories(${PROJECT_DATA} PRIVATE "${PROJECT_SOURCE_DIR}")
 
-target_link_libraries(${PROJECT} PRIVATE ${OPENGL_LIBRARIES})
+target_link_libraries(${PROJECT_DATA} PRIVATE ${OPENGL_LIBRARIES})
 
-set_target_properties(${PROJECT} PROPERTIES PUBLIC_HEADER "${HeaderFilesData}")
+set_target_properties(${PROJECT_DATA} PROPERTIES PUBLIC_HEADER "${HeaderFilesData}")
 
 if(OpenMP_CXX_FOUND)
-    target_link_libraries(${PROJECT} PRIVATE OpenMP::OpenMP_CXX)
+    target_link_libraries(${PROJECT_DATA} PRIVATE OpenMP::OpenMP_CXX)
 endif()
 
-target_compile_definitions(${PROJECT} PRIVATE _ISOC99_SOURCE _GNU_SOURCE)
+target_compile_definitions(${PROJECT_DATA} PRIVATE _ISOC99_SOURCE _GNU_SOURCE)
 
 if(HDILib_ENABLE_PID)
-    set_target_properties(${PROJECT} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    set_target_properties(${PROJECT_DATA} PROPERTIES POSITION_INDEPENDENT_CODE ON)
 endif()
 
 if(HDILib_ENABLE_CODE_ANALYSIS)
     if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-        target_compile_options(${PROJECT} PRIVATE /analyze)
+        target_compile_options(${PROJECT_DATA} PRIVATE /analyze)
     endif()
 endif()
 
-hdi_check_and_set_AVX(${PROJECT} ${HDILib_ENABLE_AVX})
-hdi_set_optimization_level(${PROJECT} ${HDILib_OPTIMIZATION_LEVEL})
+hdi_check_and_set_AVX(${PROJECT_DATA} ${HDILib_ENABLE_AVX})
+hdi_set_optimization_level(${PROJECT_DATA} ${HDILib_OPTIMIZATION_LEVEL})
 
 ########### INSTALL ##############
 if(${HDILib_INSTALL})
-    install(TARGETS ${PROJECT}
-        EXPORT ${PROJECT}Targets
+    install(TARGETS ${PROJECT_DATA}
+        EXPORT ${PROJECT_DATA}Targets
         LIBRARY DESTINATION lib/$<CONFIGURATION>>
         ARCHIVE DESTINATION lib/$<CONFIGURATION>
         PUBLIC_HEADER DESTINATION include/hdi/data
         COMPONENT hdidata
     )
 
-    install(EXPORT ${PROJECT}Targets
-            FILE ${PROJECT}Targets.cmake
+    install(EXPORT ${PROJECT_DATA}Targets
+            FILE ${PROJECT_DATA}Targets.cmake
             NAMESPACE HDI::
             DESTINATION lib/cmake/HDILib
             COMPONENT HDIDATA_TARGET

--- a/hdi/data/CMakeLists.txt
+++ b/hdi/data/CMakeLists.txt
@@ -1,16 +1,44 @@
 set(PROJECT "hdidata")
 
-# Gather list of all .h files in "/"
-file(GLOB HeaderFiles *.h)
-file(GLOB SourceFiles *.cpp)
+set(HeaderFilesData
+    abstract_data.h
+    abstract_panel_data.h
+    cluster.h
+    embedding.h
+    embedding_inl.h
+    empty_data.h
+    flow_model.h
+    flow_model_inl.h
+    histogram.h
+    histogram_inl.h
+    io.h
+    map_helpers.h
+    map_mem_eff.h
+    nano_flann.h
+    panel_data.h
+    panel_data_inl.h
+    pixel_data.h
+    shader.h
+    text_data.h
+    voxel_data.h
+    vptree.h
+)
 
-add_library(${PROJECT} STATIC ${HeaderFiles} ${SourceFiles} )
+set(SourceFilesData 
+    embedding.cpp
+    flow_model.cpp
+    histogram.cpp
+    panel_data.cpp
+    shader.cpp
+)
+
+add_library(${PROJECT} STATIC ${HeaderFilesData} ${SourceFilesData} )
 
 target_include_directories(${PROJECT} PRIVATE "${PROJECT_SOURCE_DIR}")
 
 target_link_libraries(${PROJECT} PRIVATE ${OPENGL_LIBRARIES})
 
-set_target_properties(${PROJECT} PROPERTIES PUBLIC_HEADER "${HeaderFiles}")
+set_target_properties(${PROJECT} PROPERTIES PUBLIC_HEADER "${HeaderFilesData}")
 
 if(OpenMP_CXX_FOUND)
     target_link_libraries(${PROJECT} PRIVATE OpenMP::OpenMP_CXX)

--- a/hdi/dimensionality_reduction/CMakeLists.txt
+++ b/hdi/dimensionality_reduction/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(PROJECT "hdidimensionalityreduction")
+set(PROJECT_DR "hdidimensionalityreduction")
 
 configure_file(dr_config.h.in "${CMAKE_CURRENT_LIST_DIR}/dr_config.h")
 
@@ -100,13 +100,13 @@ if(USE_VULKAN_KOMPUTE)
     add_subdirectory(gpgpu_vulkan)
 endif()
 
-add_library(${PROJECT} STATIC ${HeaderFilesDR} ${SourceFilesDR} ${ShaderFilesVulkan})
+add_library(${PROJECT_DR} STATIC ${HeaderFilesDR} ${SourceFilesDR} ${ShaderFilesVulkan})
 
-target_include_directories(${PROJECT} PRIVATE "${PROJECT_SOURCE_DIR}")
-target_include_directories(${PROJECT} PRIVATE "${hnswlib_SOURCE_DIR}")
-target_include_directories(${PROJECT} PRIVATE "${Annoy_SOURCE_DIR}")
+target_include_directories(${PROJECT_DR} PRIVATE "${PROJECT_SOURCE_DIR}")
+target_include_directories(${PROJECT_DR} PRIVATE "${hnswlib_SOURCE_DIR}")
+target_include_directories(${PROJECT_DR} PRIVATE "${Annoy_SOURCE_DIR}")
 #include the generated dr_config.h file and any others
-target_include_directories(${PROJECT} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(${PROJECT_DR} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 # prefer static linking
 if(NOT FLANN_TARGET)
@@ -138,48 +138,48 @@ if(NOT LZ4_TARGET)
 endif()
 
 message (STATUS "Flann link library: " ${FLANN_TARGET})
-target_link_libraries(${PROJECT} PRIVATE ${FLANN_TARGET})
+target_link_libraries(${PROJECT_DR} PRIVATE ${FLANN_TARGET})
 message (STATUS "Linking lz4 library " ${LZ4_TARGET})
-target_link_libraries(${PROJECT} PRIVATE ${LZ4_TARGET})
+target_link_libraries(${PROJECT_DR} PRIVATE ${LZ4_TARGET})
 
 if(OpenMP_CXX_FOUND)
-    target_link_libraries(${PROJECT} PRIVATE OpenMP::OpenMP_CXX)
+    target_link_libraries(${PROJECT_DR} PRIVATE OpenMP::OpenMP_CXX)
 endif()
 
 if (USE_VULKAN_KOMPUTE)
-    target_link_libraries(${PROJECT} PRIVATE kompute::kompute)
-    add_dependencies(${PROJECT} compile_shaders)
+    target_link_libraries(${PROJECT_DR} PRIVATE kompute::kompute)
+    add_dependencies(${PROJECT_DR} compile_shaders)
 endif()
 
 if(UNIX)
     set(THREADS_PREFER_PTHREAD_FLAG ON)
     find_package(Threads REQUIRED)
-    target_link_libraries(${PROJECT} PRIVATE Threads::Threads)
+    target_link_libraries(${PROJECT_DR} PRIVATE Threads::Threads)
 endif(UNIX)
 
-target_compile_definitions(${PROJECT} PRIVATE 
+target_compile_definitions(${PROJECT_DR} PRIVATE 
     _ISOC99_SOURCE 
     _GNU_SOURCE
     $<$<BOOL:${USE_VULKAN_KOMPUTE}>:VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=1>
 )
 
 if(HDILib_ENABLE_PID)
-    set_target_properties(${PROJECT} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    set_target_properties(${PROJECT_DR} PROPERTIES POSITION_INDEPENDENT_CODE ON)
 endif()
 
 if(HDILib_ENABLE_CODE_ANALYSIS)
     if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-        target_compile_options(${PROJECT} PRIVATE /analyze)
+        target_compile_options(${PROJECT_DR} PRIVATE /analyze)
     endif()
 endif()
 
-hdi_check_and_set_AVX(${PROJECT} ${HDILib_ENABLE_AVX})
-hdi_set_optimization_level(${PROJECT} ${HDILib_OPTIMIZATION_LEVEL})
+hdi_check_and_set_AVX(${PROJECT_DR} ${HDILib_ENABLE_AVX})
+hdi_set_optimization_level(${PROJECT_DR} ${HDILib_OPTIMIZATION_LEVEL})
 
 ########### INSTALL ##############
 if(${HDILib_INSTALL})
-    install(TARGETS ${PROJECT}
-        EXPORT ${PROJECT}Targets
+    install(TARGETS ${PROJECT_DR}
+        EXPORT ${PROJECT_DR}Targets
         LIBRARY DESTINATION lib/$<CONFIGURATION>
         ARCHIVE DESTINATION lib/$<CONFIGURATION>
         COMPONENT hdidimensionalityreduction
@@ -202,8 +202,8 @@ if(${HDILib_INSTALL})
     )
 
     # Install cmake targets file
-    install(EXPORT ${PROJECT}Targets
-            FILE ${PROJECT}Targets.cmake
+    install(EXPORT ${PROJECT_DR}Targets
+            FILE ${PROJECT_DR}Targets.cmake
             NAMESPACE HDI::
             DESTINATION lib/cmake/HDILib
             COMPONENT HDIDIMENSIONALITYREDUCTION_TARGET

--- a/hdi/dimensionality_reduction/CMakeLists.txt
+++ b/hdi/dimensionality_reduction/CMakeLists.txt
@@ -1,44 +1,114 @@
 set(PROJECT "hdidimensionalityreduction")
 
-# Gather list of all .h files in "/"
-configure_file(dr_config.h.in dr_config.h)
+configure_file(dr_config.h.in "${CMAKE_CURRENT_LIST_DIR}/dr_config.h")
+
+set(HeaderFilesDR
+    dr_config.h
+    embedding_equalizer.h
+    embedding_equalizer_inl.h
+    evaluation.h
+    evaluation_inl.h
+    gpgpu_sne/field_computation.h
+    gpgpu_sne/gpgpu_sne_compute.h
+    gpgpu_sne/gpgpu_sne_raster.h
+    gradient_descent_tsne_texture.h
+    gradient_descent_tsne_texture_inl.h
+    hd_joint_probability_generator.h
+    hd_joint_probability_generator_inl.h
+    hierarchical_sne.h
+    hierarchical_sne_inl.h
+    knn_utils.h
+    sparse_tsne_user_def_probabilities.h
+    sparse_tsne_user_def_probabilities_inl.h
+    sptree.h
+    sptree_inl.h
+    tsne.h
+    tsne_inl.h
+    tsne_parameters.h
+    tsne_random_walks.h
+    tsne_random_walks_inl.h
+    weighted_sptree.h
+    weighted_sptree_inl.h
+    wtsne.h
+    wtsne_inl.h 
+)
+
+set(SourceFilesDR
+    embedding_equalizer.cpp
+    evaluation.cpp
+    gpgpu_sne/field_computation.cpp
+    gpgpu_sne/gpgpu_sne_compute.cpp
+    gpgpu_sne/gpgpu_sne_raster.cpp
+    gradient_descent_tsne_texture.cpp
+    hd_joint_probability_generator.cpp
+    hierarchical_sne.cpp
+    knn_utils.cpp
+    sparse_tsne_user_def_probabilities.cpp
+    sptree.cpp
+    tsne.cpp
+    tsne_random_walks.cpp
+    weighted_sptree.cpp
+    wtsne.cpp
+)
+
+set(ShaderFilesVulkan "")
+set(HeaderFilesVulkan "")
 
 if(USE_VULKAN_KOMPUTE)
-    file(GLOB HeaderFiles RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.h gpgpu_sne/*.h gpgpu_vulkan/*.h gpgpu_vulkan/shaders/*.h)
-    message(STATUS "################# ${HeaderFiles} ##############")
-    file(GLOB SourceFiles RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp gpgpu_sne/*.cpp gpgpu_vulkan/*.cpp gpgpu_vulkan/shaders/*.cpp)
-    message(STATUS "################# ${SourceFiles} ##############")
-    file(GLOB_RECURSE ShaderFiles RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} gpgpu_vulkan/shaders/*.comp)
-    message(STATUS "################# ${ShaderFiles} ##############")
+    list(APPEND HeaderFilesDR
+        gpgpu_vulkan/gpgpu_sne_comp_vulkan.h
+        gpgpu_vulkan/shaders/shader_progs.h
+        gpgpu_vulkan/shaders/shaders.h
+        gpgpu_vulkan/shaders/vkUniformBufferHelper.h
+        gpgpu_vulkan/shaders/vulkan_extension.h
+        gpgpu_vulkan/tensor_config.h
+    )
+
+    list(APPEND SourceFilesDR
+        gpgpu_vulkan/gpgpu_sne_comp_vulkan.cpp
+        gpgpu_vulkan/shaders/shader_progs.cpp
+        gpgpu_vulkan/shaders/shaders.cpp
+        gpgpu_vulkan/shaders/vulkan_extension.cpp
+    )
+
+    list(APPEND ShaderFilesVulkan
+        gpgpu_vulkan/shaders/bounds.comp
+        gpgpu_vulkan/shaders/bounds_reduce.comp
+        gpgpu_vulkan/shaders/center_scale.comp
+        gpgpu_vulkan/shaders/compute_field_workgroup.comp
+        gpgpu_vulkan/shaders/compute_fields.comp
+        gpgpu_vulkan/shaders/compute_fields_enh.comp
+        gpgpu_vulkan/shaders/compute_forces.comp
+        gpgpu_vulkan/shaders/interp1.comp
+        gpgpu_vulkan/shaders/interp2.comp
+        gpgpu_vulkan/shaders/interp_fields.comp
+        gpgpu_vulkan/shaders/reset_counter.comp
+        gpgpu_vulkan/shaders/stencil.comp
+        gpgpu_vulkan/shaders/stencil2active.comp
+        gpgpu_vulkan/shaders/update.comp
+    )
+
     # each *.comp file will be glslang converted to a SPIRV .hpp file
-    set(ShaderFileHeaders "")
-    foreach(_shader_comp IN LISTS ShaderFiles)
+    set(HeaderFilesVulkan "")
+    foreach(_shader_comp IN LISTS ShaderFilesVulkan)
       get_filename_component(_COMP_ROOT ${_shader_comp} NAME_WE)
-      list(APPEND ShaderFileHeaders "gpgpu_vulkan/shaders/${_COMP_ROOT}.hpp")
+      list(APPEND HeaderFilesVulkan "gpgpu_vulkan/shaders/${_COMP_ROOT}.hpp")
     endforeach()
-    message(STATUS "################# ${ShaderFileHeaders} ##############")
-    add_library(${PROJECT} STATIC ${HeaderFiles} ${SourceFiles} ${ShaderFiles})
-    source_group(Shaders FILES ${ShaderFiles})
+
+    message(STATUS "Add vulkan subdir")
+    add_subdirectory(gpgpu_vulkan)
+
+    source_group(Shaders FILES ${ShaderFilesVulkan})
     add_dependencies(${PROJECT} compile_shaders)
-    find_package(fmt CONFIG REQUIRED)
-    find_package(kompute CONFIG REQUIRED)
-    target_compile_definitions(${PROJECT} PRIVATE VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=1)
-else()
-    file(GLOB HeaderFiles RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.h gpgpu_sne/*.h)
-    message(STATUS "################# ${HeaderFiles} ##############")
-    file(GLOB SourceFiles RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp gpgpu_sne/*.cpp)
-    message(STATUS "################# ${SourceFiles} ##############")
-    add_library(${PROJECT} STATIC ${HeaderFiles} ${SourceFiles} )
 endif()
 
-
+add_library(${PROJECT} STATIC ${HeaderFilesDR} ${SourceFilesDR} ${ShaderFilesVulkan})
 
 target_include_directories(${PROJECT} PRIVATE "${PROJECT_SOURCE_DIR}")
 target_include_directories(${PROJECT} PRIVATE "${hnswlib_SOURCE_DIR}")
 target_include_directories(${PROJECT} PRIVATE "${Annoy_SOURCE_DIR}")
 #include the generated dr_config.h file and any others
 target_include_directories(${PROJECT} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-
 
 # prefer static linking
 if(NOT FLANN_TARGET)
@@ -78,7 +148,21 @@ if(OpenMP_CXX_FOUND)
     target_link_libraries(${PROJECT} PRIVATE OpenMP::OpenMP_CXX)
 endif()
 
-target_compile_definitions(${PROJECT} PRIVATE _ISOC99_SOURCE _GNU_SOURCE)
+if (USE_VULKAN_KOMPUTE)
+    target_link_libraries(${PROJECT} PRIVATE kompute::kompute)
+endif()
+
+if(UNIX)
+    set(THREADS_PREFER_PTHREAD_FLAG ON)
+    find_package(Threads REQUIRED)
+    target_link_libraries(${PROJECT} PRIVATE Threads::Threads)
+endif(UNIX)
+
+target_compile_definitions(${PROJECT} PRIVATE 
+    _ISOC99_SOURCE 
+    _GNU_SOURCE
+    $<$<BOOL:${USE_VULKAN_KOMPUTE}>:VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=1>
+)
 
 if(HDILib_ENABLE_PID)
     set_target_properties(${PROJECT} PROPERTIES POSITION_INDEPENDENT_CODE ON)
@@ -93,16 +177,6 @@ endif()
 hdi_check_and_set_AVX(${PROJECT} ${HDILib_ENABLE_AVX})
 hdi_set_optimization_level(${PROJECT} ${HDILib_OPTIMIZATION_LEVEL})
 
-if (USE_VULKAN_KOMPUTE)
-    target_link_libraries(${PROJECT} PRIVATE kompute::kompute)
-endif()
-
-if(UNIX)
-    set(THREADS_PREFER_PTHREAD_FLAG ON)
-    find_package(Threads REQUIRED)
-    target_link_libraries(${PROJECT} PRIVATE Threads::Threads)
-endif(UNIX)
-
 ########### INSTALL ##############
 if(${HDILib_INSTALL})
     install(TARGETS ${PROJECT}
@@ -114,8 +188,8 @@ if(${HDILib_INSTALL})
 
     # Preserve the header hierarchy by explicit install
     # the CMake PUBLIC_HEADER target property flattens it if used.
-    set(_ALL_HEADERS ${HeaderFiles} ${ShaderFileHeaders})
-    # message("All headers ${DR_HEADER}")
+    set(_ALL_HEADERS ${HeaderFilesDR} ${HeaderFilesVulkan})
+
     install(CODE "foreach(DR_HEADER ${_ALL_HEADERS})
             message(STATUS \"Installing: \${DR_HEADER} to \${CMAKE_INSTALL_PREFIX}/include/hdi/dimensionality_reduction\")
             execute_process(

--- a/hdi/dimensionality_reduction/CMakeLists.txt
+++ b/hdi/dimensionality_reduction/CMakeLists.txt
@@ -209,8 +209,3 @@ if(${HDILib_INSTALL})
             COMPONENT HDIDIMENSIONALITYREDUCTION_TARGET
     )
 endif()
-
-if(USE_VULKAN_KOMPUTE)
-    message(STATUS "Add vulkan subdir")
-    add_subdirectory(gpgpu_vulkan)
-endif()

--- a/hdi/dimensionality_reduction/CMakeLists.txt
+++ b/hdi/dimensionality_reduction/CMakeLists.txt
@@ -94,12 +94,10 @@ if(USE_VULKAN_KOMPUTE)
       get_filename_component(_COMP_ROOT ${_shader_comp} NAME_WE)
       list(APPEND HeaderFilesVulkan "gpgpu_vulkan/shaders/${_COMP_ROOT}.hpp")
     endforeach()
-
+    
+    source_group(Shaders FILES ${ShaderFilesVulkan})
     message(STATUS "Add vulkan subdir")
     add_subdirectory(gpgpu_vulkan)
-
-    source_group(Shaders FILES ${ShaderFilesVulkan})
-    add_dependencies(${PROJECT} compile_shaders)
 endif()
 
 add_library(${PROJECT} STATIC ${HeaderFilesDR} ${SourceFilesDR} ${ShaderFilesVulkan})
@@ -150,6 +148,7 @@ endif()
 
 if (USE_VULKAN_KOMPUTE)
     target_link_libraries(${PROJECT} PRIVATE kompute::kompute)
+    add_dependencies(${PROJECT} compile_shaders)
 endif()
 
 if(UNIX)

--- a/hdi/dimensionality_reduction/gpgpu_vulkan/CMakeLists.txt
+++ b/hdi/dimensionality_reduction/gpgpu_vulkan/CMakeLists.txt
@@ -1,3 +1,1 @@
-find_package(fmt CONFIG REQUIRED)
-find_package(kompute CONFIG REQUIRED)
 add_subdirectory(shaders)

--- a/hdi/utils/CMakeLists.txt
+++ b/hdi/utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(PROJECT "hdiutils")
+set(PROJECT_UTILS "hdiutils")
 
 set(HeaderFilesUtils
     abstract_log.h
@@ -37,36 +37,38 @@ set(SourceFilesUtils
 
 if(APPLE)
     # Do not include or build glad on Apple
-    set(HeaderFiles ${HeaderFilesUtils})
     list(REMOVE_ITEM SourceFilesUtils "glad.cpp")
 else()
-    set(HeaderFiles ${HeaderFilesUtils} ${HeaderFilesGlad})
+    list(APPEND HeaderFilesUtils ${HeaderFilesGlad})
 endif()
 
-add_library(${PROJECT} STATIC ${HeaderFiles} ${SourceFilesUtils} ${Resources} )
+message(STATUS "HeaderFilesUtils: ${HeaderFilesUtils}")
+message(STATUS "SourceFilesUtils: ${SourceFilesUtils}")
 
-target_include_directories(${PROJECT} PRIVATE "${PROJECT_SOURCE_DIR}")
+add_library(${PROJECT_UTILS} STATIC ${HeaderFilesUtils} ${SourceFilesUtils})
 
-#set_target_properties(${PROJECT} PROPERTIES PUBLIC_HEADER "${HeaderFiles}")
+target_include_directories(${PROJECT_UTILS} PRIVATE "${PROJECT_SOURCE_DIR}")
+
+#set_target_properties(${PROJECT_UTILS} PROPERTIES PUBLIC_HEADER "${HeaderFiles}")
 
 if(OpenMP_CXX_FOUND)
-    target_link_libraries(${PROJECT} PRIVATE OpenMP::OpenMP_CXX)
+    target_link_libraries(${PROJECT_UTILS} PRIVATE OpenMP::OpenMP_CXX)
 endif()
 
-target_compile_definitions(${PROJECT} PRIVATE _ISOC99_SOURCE _GNU_SOURCE)
+target_compile_definitions(${PROJECT_UTILS} PRIVATE _ISOC99_SOURCE _GNU_SOURCE)
 
 if(HDILib_ENABLE_PID)
-    set_target_properties(${PROJECT} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    set_target_properties(${PROJECT_UTILS} PROPERTIES POSITION_INDEPENDENT_CODE ON)
 endif()
 
 if(HDILib_ENABLE_CODE_ANALYSIS)
     if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-        target_compile_options(${PROJECT} PRIVATE /analyze)
+        target_compile_options(${PROJECT_UTILS} PRIVATE /analyze)
     endif()
 endif()
 
-hdi_check_and_set_AVX(${PROJECT} ${HDILib_ENABLE_AVX})
-hdi_set_optimization_level(${PROJECT} ${HDILib_OPTIMIZATION_LEVEL})
+hdi_check_and_set_AVX(${PROJECT_UTILS} ${HDILib_ENABLE_AVX})
+hdi_set_optimization_level(${PROJECT_UTILS} ${HDILib_OPTIMIZATION_LEVEL})
 
 if (UNIX)
     target_link_libraries (hdiutils PRIVATE ${CMAKE_DL_LIBS}) # glad.cpp requires -ldl
@@ -74,8 +76,8 @@ endif (UNIX)
 
 ########### INSTALL ##############
 if(${HDILib_INSTALL})
-    install(TARGETS ${PROJECT}
-        EXPORT ${PROJECT}Targets
+    install(TARGETS ${PROJECT_UTILS}
+        EXPORT ${PROJECT_UTILS}Targets
         LIBRARY DESTINATION lib/$<CONFIGURATION>
         ARCHIVE DESTINATION lib/$<CONFIGURATION>
         COMPONENT hdiutils
@@ -95,8 +97,8 @@ if(${HDILib_INSTALL})
         COMPONENT PUBLIC_HEADERS
     )
 
-    install(EXPORT ${PROJECT}Targets
-            FILE ${PROJECT}Targets.cmake
+    install(EXPORT ${PROJECT_UTILS}Targets
+            FILE ${PROJECT_UTILS}Targets.cmake
             NAMESPACE HDI::
             DESTINATION lib/cmake/HDILib
             COMPONENT HDIUTILS_TARGET

--- a/hdi/utils/CMakeLists.txt
+++ b/hdi/utils/CMakeLists.txt
@@ -49,7 +49,7 @@ add_library(${PROJECT_UTILS} STATIC ${HeaderFilesUtils} ${SourceFilesUtils})
 
 target_include_directories(${PROJECT_UTILS} PRIVATE "${PROJECT_SOURCE_DIR}")
 
-#set_target_properties(${PROJECT_UTILS} PROPERTIES PUBLIC_HEADER "${HeaderFiles}")
+#set_target_properties(${PROJECT_UTILS} PROPERTIES PUBLIC_HEADER "${HeaderFilesUtils}")
 
 if(OpenMP_CXX_FOUND)
     target_link_libraries(${PROJECT_UTILS} PRIVATE OpenMP::OpenMP_CXX)
@@ -85,7 +85,7 @@ if(${HDILib_INSTALL})
 
     # Preserve the header hierarchy by explicit install
     # the CMake PUBLIC_HEADER target property flattens it if used.
-    install(CODE "foreach(HEADER ${HeaderFiles})
+    install(CODE "foreach(HEADER ${HeaderFilesUtils})
             message(STATUS \"Installing: \${HEADER} to \${CMAKE_INSTALL_PREFIX}/include/hdi/utils\")
             execute_process(
                 COMMAND \"${CMAKE_COMMAND}\" -E copy_if_different 

--- a/hdi/utils/CMakeLists.txt
+++ b/hdi/utils/CMakeLists.txt
@@ -24,7 +24,7 @@ set(HeaderFilesGlad
     glad/KHR/khrplatform.h
 )
 
-set(SourceFilesUtilsUtils
+set(SourceFilesUtils
     cout_log.cpp
     dataset_utils.cpp
     glad.cpp

--- a/hdi/utils/CMakeLists.txt
+++ b/hdi/utils/CMakeLists.txt
@@ -1,19 +1,49 @@
 set(PROJECT "hdiutils")
 
-# Gather list of all .h files in "/"
-file(GLOB UtilsHeaderFiles RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.h)
-file(GLOB GladHeaderFiles RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} glad/*.h glad/KHR/*.h)
-file(GLOB SourceFiles *.cpp)
+set(HeaderFilesUtils
+    abstract_log.h
+    assert_by_exception.h
+    cout_log.h
+    dataset_utils.h
+    graph_algorithms.h
+    graph_algorithms_inl.h
+    log_helper_functions.h
+    log_progress.h
+    math_utils.h
+    math_utils_inl.h
+    memory_utils.h
+    scoped_timers.h
+    scoped_timers_inl.h
+    timers.h
+    timing_utils.h
+    vector_utils.h
+)
+
+set(HeaderFilesGlad
+    glad/glad.h
+    glad/KHR/khrplatform.h
+)
+
+set(SourceFilesUtilsUtils
+    cout_log.cpp
+    dataset_utils.cpp
+    glad.cpp
+    graph_algorithms.cpp
+    log_progress.cpp
+    math_utils.cpp
+    memory_utils.cpp
+    timers.cpp
+)
 
 if(APPLE)
     # Do not include or build glad on Apple
-    set(HeaderFiles ${UtilsHeaderFiles})
-    list(REMOVE_ITEM SourceFiles "${CMAKE_CURRENT_SOURCE_DIR}/glad.cpp")
+    set(HeaderFiles ${HeaderFilesUtils})
+    list(REMOVE_ITEM SourceFilesUtils "glad.cpp")
 else()
-    set(HeaderFiles ${UtilsHeaderFiles} ${GladHeaderFiles})
+    set(HeaderFiles ${HeaderFilesUtils} ${HeaderFilesGlad})
 endif()
 
-add_library(${PROJECT} STATIC ${HeaderFiles} ${SourceFiles} ${Resources} )
+add_library(${PROJECT} STATIC ${HeaderFiles} ${SourceFilesUtils} ${Resources} )
 
 target_include_directories(${PROJECT} PRIVATE "${PROJECT_SOURCE_DIR}")
 


### PR DESCRIPTION
- List source files instead of finding them
- Find fmt and kompute dependency only once
- Unique target project names
- Do not include build directory

This will simplify alternatives to #59 and #60