### PR TITLE
Fix built without kompute feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ option(HDILib_ENABLE_PID "Set POSITION_INDEPENDENT_CODE property for all targets
 option(HDILib_INSTALL "Enable installation of the HDILib" ON)
 option(HDILib_BUILD_TESTS "Build tests for HDILib" OFF)
 option(HDILib_BUILD_EXAMPLE "Enable building the test executables" OFF)
-option(USE_VULKAN_KOMPUTE "Build the repo using the Vulkan kompute library - by default ON" ON)
+option(HDILib_USE_VULKAN_KOMPUTE "Build the repo using the Vulkan kompute library - by default ON" ON)
 set(HDILib_OPTIMIZATION_LEVEL "2" CACHE STRING "Optimization level for all targets in release builds, e.g. 0, 1, 2")
 set(HDILib_VERSION "latest" CACHE STRING "HDILib Library version")
 
@@ -25,7 +25,7 @@ if(HDILib_ENABLE_PID)
     message(STATUS "Position independent code compilation ON")
 endif()
 
-if(USE_VULKAN_KOMPUTE)
+if(HDILib_USE_VULKAN_KOMPUTE)
     list(APPEND VCPKG_MANIFEST_FEATURES "kompute")
 
     # Make sure vcpkg toolchain is picked up (or pass -DCMAKE_TOOLCHAIN_FILE=...)
@@ -170,7 +170,7 @@ endif()
 
 message(STATUS "annoy at ${Annoy_SOURCE_DIR}")
 
-if (USE_VULKAN_KOMPUTE)
+if (HDILib_USE_VULKAN_KOMPUTE)
     find_package(fmt CONFIG REQUIRED)
     find_package(kompute CONFIG REQUIRED)
 
@@ -320,7 +320,7 @@ if(${HDILib_INSTALL})
             DESTINATION lib/cmake/HDILib
             COMPONENT HDI_PACKAGE
     )
-    if (USE_VULKAN_KOMPUTE)
+    if (HDILib_USE_VULKAN_KOMPUTE)
       # TBD possibly move this to an external script
       # Install the config.cmake files for the vcpkg dependencies
       message(STATUS "Fix config in ${CMAKE_CURRENT_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/share/kompute/komputeTargets-*.cmake")

--- a/hdi/dimensionality_reduction/CMakeLists.txt
+++ b/hdi/dimensionality_reduction/CMakeLists.txt
@@ -54,7 +54,7 @@ set(SourceFilesDR
 set(ShaderFilesVulkan "")
 set(HeaderFilesVulkan "")
 
-if(USE_VULKAN_KOMPUTE)
+if(HDILib_USE_VULKAN_KOMPUTE)
     list(APPEND HeaderFilesDR
         gpgpu_vulkan/gpgpu_sne_comp_vulkan.h
         gpgpu_vulkan/shaders/shader_progs.h
@@ -146,7 +146,7 @@ if(OpenMP_CXX_FOUND)
     target_link_libraries(${PROJECT_DR} PRIVATE OpenMP::OpenMP_CXX)
 endif()
 
-if (USE_VULKAN_KOMPUTE)
+if (HDILib_USE_VULKAN_KOMPUTE)
     target_link_libraries(${PROJECT_DR} PRIVATE kompute::kompute)
     add_dependencies(${PROJECT_DR} compile_shaders)
 endif()
@@ -160,7 +160,7 @@ endif(UNIX)
 target_compile_definitions(${PROJECT_DR} PRIVATE 
     _ISOC99_SOURCE 
     _GNU_SOURCE
-    $<$<BOOL:${USE_VULKAN_KOMPUTE}>:VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=1>
+    $<$<BOOL:${HDILib_USE_VULKAN_KOMPUTE}>:VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=1>
 )
 
 if(HDILib_ENABLE_PID)

--- a/hdi/dimensionality_reduction/dr_config.h.in
+++ b/hdi/dimensionality_reduction/dr_config.h.in
@@ -1,2 +1,2 @@
-#cmakedefine USE_VULKAN_KOMPUTE
+#cmakedefine HDILib_USE_VULKAN_KOMPUTE
 #cmakedefine KOMPUTE_OPT_LOG_LEVEL_DISABLED

--- a/hdi/dimensionality_reduction/gpgpu_vulkan/gpgpu_sne_comp_vulkan.h
+++ b/hdi/dimensionality_reduction/gpgpu_vulkan/gpgpu_sne_comp_vulkan.h
@@ -1,7 +1,7 @@
 // This file contains the implementation of the GPGPU SNE computation using Vulkan.
 // The structure is similar to gpgpu_sne_compute.h but adapted for Vulkan API using the 
 // vulkan kompute library.
-//#ifdef USE_VULKAN_KOMPUTE 
+//#ifdef HDILib_USE_VULKAN_KOMPUTE 
 #pragma once
 
 #include "hdi/data/shader.h"

--- a/hdi/dimensionality_reduction/gradient_descent_tsne_texture.h
+++ b/hdi/dimensionality_reduction/gradient_descent_tsne_texture.h
@@ -37,7 +37,7 @@
 #include "hdi/data/map_mem_eff.h"
 #include "hdi/dimensionality_reduction/dr_config.h"
 #include "hdi/dimensionality_reduction/gpgpu_sne/gpgpu_sne_compute.h"
-#ifdef USE_VULKAN_KOMPUTE
+#ifdef HDILib_USE_VULKAN_KOMPUTE
 #include "hdi/dimensionality_reduction/gpgpu_vulkan/gpgpu_sne_comp_vulkan.h"
 #endif
 #include "hdi/dimensionality_reduction/gpgpu_sne/gpgpu_sne_raster.h"
@@ -63,7 +63,7 @@ namespace hdi {
 #ifndef __APPLE__
         COMPUTE_SHADER, 
 #endif
-        #ifdef USE_VULKAN_KOMPUTE
+        #ifdef HDILib_USE_VULKAN_KOMPUTE
         COMPUTE_SHADER_VULKAN,
 #endif
         AUTO_DETECT
@@ -119,7 +119,7 @@ namespace hdi {
 #ifndef __APPLE__
         if (_gpgpu_type == COMPUTE_SHADER)
           _gpgpu_compute_tsne.setScalingFactor(factor);
-#ifdef USE_VULKAN_KOMPUTE
+#ifdef HDILib_USE_VULKAN_KOMPUTE
         else if (_gpgpu_type == COMPUTE_SHADER_VULKAN)
           _gpgpu_vulkan_compute_tsne.setScalingFactor(factor);
 #endif
@@ -138,7 +138,7 @@ namespace hdi {
       // only valid on APPLE VULKAN debug - otherwise returns nullptr
       // The caller should cast back to vk::Device *
       void *getDevice() {
-#if defined(__APPLE__) && defined(USE_VULKAN_KOMPUTE)
+#if defined(__APPLE__) && defined(HDILib_USE_VULKAN_KOMPUTE)
         return _gpgpu_vulkan_compute_tsne.getDevice().get();
 #else
         return nullptr;
@@ -182,7 +182,7 @@ namespace hdi {
 #ifndef __APPLE__
       GpgpuSneCompute _gpgpu_compute_tsne;
 #endif
-#ifdef USE_VULKAN_KOMPUTE
+#ifdef HDILib_USE_VULKAN_KOMPUTE
       GpgpuSneVulkan _gpgpu_vulkan_compute_tsne;
 #endif
       GpgpuSneType _gpgpu_type;

--- a/hdi/dimensionality_reduction/gradient_descent_tsne_texture.h
+++ b/hdi/dimensionality_reduction/gradient_descent_tsne_texture.h
@@ -63,7 +63,7 @@ namespace hdi {
 #ifndef __APPLE__
         COMPUTE_SHADER, 
 #endif
-        #ifdef HDILib_USE_VULKAN_KOMPUTE
+#ifdef HDILib_USE_VULKAN_KOMPUTE
         COMPUTE_SHADER_VULKAN,
 #endif
         AUTO_DETECT

--- a/hdi/dimensionality_reduction/gradient_descent_tsne_texture.h
+++ b/hdi/dimensionality_reduction/gradient_descent_tsne_texture.h
@@ -33,18 +33,19 @@
 #ifndef GRADIENT_DESCENT_TSNE_TEXTURE_H
 #define GRADIENT_DESCENT_TSNE_TEXTURE_H
 
-#include <vector>
-#include <stdint.h>
-#include "hdi/utils/assert_by_exception.h"
-#include "hdi/utils/abstract_log.h"
-#include <map>
-#include <unordered_map>
 #include "hdi/data/embedding.h"
 #include "hdi/data/map_mem_eff.h"
-#include "gpgpu_sne/gpgpu_sne_compute.h"
-#include "gpgpu_vulkan/gpgpu_sne_comp_vulkan.h"
-#include "gpgpu_sne/gpgpu_sne_raster.h"
-#include "tsne_parameters.h"
+#include "hdi/dimensionality_reduction/dr_config.h"
+#include "hdi/dimensionality_reduction/gpgpu_sne/gpgpu_sne_compute.h"
+#ifdef USE_VULKAN_KOMPUTE
+#include "hdi/dimensionality_reduction/gpgpu_vulkan/gpgpu_sne_comp_vulkan.h"
+#endif
+#include "hdi/dimensionality_reduction/gpgpu_sne/gpgpu_sne_raster.h"
+#include "hdi/dimensionality_reduction/tsne_parameters.h"
+#include "hdi/utils/abstract_log.h"
+
+#include <vector>
+#include <stdint.h>
 #include <array>
 
 namespace hdi {
@@ -56,9 +57,17 @@ namespace hdi {
     */
     class GradientDescentTSNETexture {
     public:
-    //#ifndef __APPLE__
-      typedef enum { RASTER, COMPUTE_SHADER, COMPUTE_SHADER_VULKAN, AUTO_DETECT } GpgpuSneType;
-    //#endif
+      typedef enum
+      {
+        RASTER,
+#ifndef __APPLE__
+        COMPUTE_SHADER, 
+#endif
+        #ifdef USE_VULKAN_KOMPUTE
+        COMPUTE_SHADER_VULKAN,
+#endif
+        AUTO_DETECT
+      } GpgpuSneType;
       typedef float scalar_type;
       typedef std::vector<hdi::data::MapMemEff<uint32_t, float>> sparse_scalar_matrix_type;
       typedef std::vector<scalar_type> scalar_vector_type;
@@ -67,10 +76,8 @@ namespace hdi {
     public:
       GradientDescentTSNETexture();
 
-    //#ifndef __APPLE__
       //! Override the default compute type.
       void setType(GpgpuSneType _tsneType);
-    //#endif
       //! Initialize the class with a list of distributions. A joint-probability distribution will be computed as in the tSNE algorithm
       void initialize(const sparse_scalar_matrix_type& probabilities, data::Embedding<scalar_type>* embedding, TsneParameters params = TsneParameters());
       //! Initialize the class with a joint-probability distribution. Note that it must be provided non initialized and with the weight of each row equal to 2.
@@ -109,16 +116,18 @@ namespace hdi {
 
       //! Set the adaptive texture scaling
       void setResolutionFactor(float factor) {
-      #ifndef __APPLE__
+#ifndef __APPLE__
         if (_gpgpu_type == COMPUTE_SHADER)
           _gpgpu_compute_tsne.setScalingFactor(factor);
+#ifdef USE_VULKAN_KOMPUTE
         else if (_gpgpu_type == COMPUTE_SHADER_VULKAN)
           _gpgpu_vulkan_compute_tsne.setScalingFactor(factor);
+#endif
         else
           _gpgpu_raster_tsne.setScalingFactor(factor);
-      #else
+#else
         _gpgpu_raster_tsne.setScalingFactor(factor);
-      #endif
+#endif
       }
       bool isInitialized() { return _initialized == true; }
       //! Exageration baseline
@@ -129,7 +138,7 @@ namespace hdi {
       // only valid on APPLE VULKAN debug - otherwise returns nullptr
       // The caller should cast back to vk::Device *
       void *getDevice() {
-#ifdef __APPLE__
+#if defined(__APPLE__) && defined(USE_VULKAN_KOMPUTE)
         return _gpgpu_vulkan_compute_tsne.getDevice().get();
 #else
         return nullptr;
@@ -170,10 +179,12 @@ namespace hdi {
       scalar_vector_type _Q; //! Conditional probalility distribution in the Low-dimensional space
       scalar_type _normalization_Q; //! Normalization factor of Q - Z in the original paper
 
-    #ifndef __APPLE__
+#ifndef __APPLE__
       GpgpuSneCompute _gpgpu_compute_tsne;
-    #endif // __APPLE__
+#endif
+#ifdef USE_VULKAN_KOMPUTE
       GpgpuSneVulkan _gpgpu_vulkan_compute_tsne;
+#endif
       GpgpuSneType _gpgpu_type;
 
       GpgpuSneRaster _gpgpu_raster_tsne;

--- a/hdi/dimensionality_reduction/gradient_descent_tsne_texture_inl.h
+++ b/hdi/dimensionality_reduction/gradient_descent_tsne_texture_inl.h
@@ -56,7 +56,7 @@ namespace hdi {
     }
 
     void GradientDescentTSNETexture::setType(GpgpuSneType tsne_type) {
-#ifdef USE_VULKAN_KOMPUTE
+#ifdef HDILib_USE_VULKAN_KOMPUTE
       const bool vulkan_supported = GpgpuSneVulkan::isVulkanSupported();
 #else
       constexpr bool vulkan_supported = false;
@@ -69,7 +69,7 @@ namespace hdi {
       #else
         std::vector<GpgpuSneType> priotitized_types = {
           COMPUTE_SHADER, 
-#ifdef USE_VULKAN_KOMPUTE
+#ifdef HDILib_USE_VULKAN_KOMPUTE
           COMPUTE_SHADER_VULKAN, 
 #endif
           RASTER
@@ -87,7 +87,7 @@ namespace hdi {
             _gpgpu_type = COMPUTE_SHADER;
             break;
           }
-#ifdef USE_VULKAN_KOMPUTE
+#ifdef HDILib_USE_VULKAN_KOMPUTE
           else if (type == COMPUTE_SHADER_VULKAN && vulkan_supported) {
             _gpgpu_type = COMPUTE_SHADER_VULKAN;
             break;
@@ -110,7 +110,7 @@ namespace hdi {
         else if (tsne_type == RASTER && !glV33_supported) {
           throw std::runtime_error("OpenGL 3.3 not supported, cannot use rasterization fallback");
         }
-#ifdef USE_VULKAN_KOMPUTE
+#ifdef HDILib_USE_VULKAN_KOMPUTE
         else if (tsne_type == COMPUTE_SHADER_VULKAN) {
           if (vulkan_supported) {
             _gpgpu_type = COMPUTE_SHADER_VULKAN;
@@ -146,7 +146,7 @@ namespace hdi {
 
     void GradientDescentTSNETexture::clear() {
       _embedding->clear();
-#ifdef USE_VULKAN_KOMPUTE
+#ifdef HDILib_USE_VULKAN_KOMPUTE
       if (_gpgpu_type == COMPUTE_SHADER_VULKAN)
         _gpgpu_vulkan_compute_tsne.clean();
 #endif
@@ -195,7 +195,7 @@ namespace hdi {
         _gpgpu_compute_tsne.initialize(_embedding, _params, _P);
       else {
 #endif
-#ifdef USE_VULKAN_KOMPUTE
+#ifdef HDILib_USE_VULKAN_KOMPUTE
         if (_gpgpu_type == COMPUTE_SHADER_VULKAN)
           _gpgpu_vulkan_compute_tsne.initialize(_embedding, _params, _P);
         else// (_tsne_type == RASTER)
@@ -238,7 +238,7 @@ namespace hdi {
         _gpgpu_compute_tsne.initialize(_embedding, _params, _P);
       else
 #endif
-#ifdef USE_VULKAN_KOMPUTE
+#ifdef HDILib_USE_VULKAN_KOMPUTE
       if (_gpgpu_type == COMPUTE_SHADER_VULKAN)
         _gpgpu_vulkan_compute_tsne.initialize(_embedding, _params, _P);
       else// (_tsne_type == RASTER)
@@ -257,7 +257,7 @@ namespace hdi {
       }
       _params = params;
 
-#ifdef USE_VULKAN_KOMPUTE
+#ifdef HDILib_USE_VULKAN_KOMPUTE
       // vulkan is possible on any platform.
       if (_gpgpu_type == COMPUTE_SHADER_VULKAN)
         _gpgpu_vulkan_compute_tsne.updateParams(params);
@@ -359,7 +359,7 @@ namespace hdi {
       }
       else
 #endif
-#ifdef USE_VULKAN_KOMPUTE
+#ifdef HDILib_USE_VULKAN_KOMPUTE
       if (_gpgpu_type == COMPUTE_SHADER_VULKAN) {
         _gpgpu_vulkan_compute_tsne.compute(_embedding, exaggerationFactor(), _iteration, mult);
         kl_divergence = _gpgpu_vulkan_compute_tsne.kl_divergence;

--- a/hdi/dimensionality_reduction/gradient_descent_tsne_texture_inl.h
+++ b/hdi/dimensionality_reduction/gradient_descent_tsne_texture_inl.h
@@ -62,54 +62,60 @@ namespace hdi {
       constexpr bool vulkan_supported = false;
 #endif
 
-      #ifdef __APPLE__
-        std::vector<GpgpuSneType> priotitized_types = { COMPUTE_SHADER_VULKAN, RASTER };
-        bool glV43_supported = false; // Compute shaders are not supported on macOS.
-        bool glV33_supported = true;
-      #else
-        std::vector<GpgpuSneType> priotitized_types = {
-          COMPUTE_SHADER, 
-#ifdef HDILib_USE_VULKAN_KOMPUTE
-          COMPUTE_SHADER_VULKAN, 
+#ifdef __APPLE__
+      const bool glV43_supported = false; // Compute shaders are not supported on macOS.
+      const bool glV33_supported = true;
+#else
+      const bool glV43_supported = GLAD_GL_VERSION_4_3;
+      const bool glV33_supported = GLAD_GL_VERSION_3_3;
 #endif
-          RASTER
-        };
-        bool glV43_supported = GLAD_GL_VERSION_4_3;
-        bool glV33_supported = GLAD_GL_VERSION_3_3;
-      #endif
+
+      std::vector<GpgpuSneType> priotitized_types = {
+#ifndef __APPLE__
+        COMPUTE_SHADER,
+#endif
+  #ifdef HDILib_USE_VULKAN_KOMPUTE
+        COMPUTE_SHADER_VULKAN,
+#endif
+        RASTER
+      };
 
       if (tsne_type == AUTO_DETECT)
       {
         //resolve the optimal type to use based on the available OpenGL version
 
         for (const auto& type : priotitized_types) {
-          if (type == COMPUTE_SHADER && glV43_supported) {
+          if (type == RASTER && glV33_supported) {
+            std::cout << "Compute shaders not available, using rasterization fallback" << std::endl;
+            _gpgpu_type = RASTER;
+            break;
+          }
+#ifndef __APPLE__
+          else if (type == COMPUTE_SHADER && glV43_supported) {
             _gpgpu_type = COMPUTE_SHADER;
             break;
           }
+#endif
 #ifdef HDILib_USE_VULKAN_KOMPUTE
           else if (type == COMPUTE_SHADER_VULKAN && vulkan_supported) {
             _gpgpu_type = COMPUTE_SHADER_VULKAN;
             break;
           }
 #endif
-          else if (type == RASTER && glV33_supported) {
-            std::cout << "Compute shaders not available, using rasterization fallback" << std::endl;
-            _gpgpu_type = RASTER;
-            break;
-          }
         }
       }
       else
         // Do our best to set what the user asked for. 
         // Failing that choose a sensible fallback and log it.
-        if (tsne_type == COMPUTE_SHADER && !glV43_supported) {
+        if (tsne_type == RASTER && !glV33_supported) {
+          throw std::runtime_error("OpenGL 3.3 not supported, cannot use rasterization fallback");
+        }
+#ifndef __APPLE__
+        else if (tsne_type == COMPUTE_SHADER && !glV43_supported) {
           std::cout << "OpenGL 4.3 not supported, using rasterization fallback" << std::endl;
           _gpgpu_type = RASTER;
         }
-        else if (tsne_type == RASTER && !glV33_supported) {
-          throw std::runtime_error("OpenGL 3.3 not supported, cannot use rasterization fallback");
-        }
+#endif
 #ifdef HDILib_USE_VULKAN_KOMPUTE
         else if (tsne_type == COMPUTE_SHADER_VULKAN) {
           if (vulkan_supported) {

--- a/hdi/dimensionality_reduction/gradient_descent_tsne_texture_inl.h
+++ b/hdi/dimensionality_reduction/gradient_descent_tsne_texture_inl.h
@@ -34,12 +34,11 @@
 #ifndef GRADIENT_DESCENT_TSNE_TEXTURE_INL
 #define GRADIENT_DESCENT_TSNE_TEXTURE_INL
 
+#include "hdi/dimensionality_reduction/dr_config.h"
 #include "hdi/dimensionality_reduction/gradient_descent_tsne_texture.h"
 #include "hdi/utils/math_utils.h"
 #include "hdi/utils/log_helper_functions.h"
-#include "hdi/utils/scoped_timers.h"
-#include "sptree.h"
-#include "dr_config.h"
+
 #include <random>
 
 namespace hdi {
@@ -57,19 +56,27 @@ namespace hdi {
     }
 
     void GradientDescentTSNETexture::setType(GpgpuSneType tsne_type) {
-      bool vulkan_supported = GpgpuSneVulkan::isVulkanSupported();
+#ifdef USE_VULKAN_KOMPUTE
+      const bool vulkan_supported = GpgpuSneVulkan::isVulkanSupported();
+#else
+      constexpr bool vulkan_supported = false;
+#endif
 
       #ifdef __APPLE__
         std::vector<GpgpuSneType> priotitized_types = { COMPUTE_SHADER_VULKAN, RASTER };
         bool glV43_supported = false; // Compute shaders are not supported on macOS.
         bool glV33_supported = true;
       #else
-        std::vector<GpgpuSneType> priotitized_types = { COMPUTE_SHADER, COMPUTE_SHADER_VULKAN, RASTER };
+        std::vector<GpgpuSneType> priotitized_types = {
+          COMPUTE_SHADER, 
+#ifdef USE_VULKAN_KOMPUTE
+          COMPUTE_SHADER_VULKAN, 
+#endif
+          RASTER
+        };
         bool glV43_supported = GLAD_GL_VERSION_4_3;
         bool glV33_supported = GLAD_GL_VERSION_3_3;
       #endif
-
-
 
       if (tsne_type == AUTO_DETECT)
       {
@@ -80,10 +87,12 @@ namespace hdi {
             _gpgpu_type = COMPUTE_SHADER;
             break;
           }
+#ifdef USE_VULKAN_KOMPUTE
           else if (type == COMPUTE_SHADER_VULKAN && vulkan_supported) {
             _gpgpu_type = COMPUTE_SHADER_VULKAN;
             break;
           }
+#endif
           else if (type == RASTER && glV33_supported) {
             std::cout << "Compute shaders not available, using rasterization fallback" << std::endl;
             _gpgpu_type = RASTER;
@@ -94,7 +103,15 @@ namespace hdi {
       else
         // Do our best to set what the user asked for. 
         // Failing that choose a sensible fallback and log it.
-        if (tsne_type == COMPUTE_SHADER_VULKAN) {
+        if (tsne_type == COMPUTE_SHADER && !glV43_supported) {
+          std::cout << "OpenGL 4.3 not supported, using rasterization fallback" << std::endl;
+          _gpgpu_type = RASTER;
+        }
+        else if (tsne_type == RASTER && !glV33_supported) {
+          throw std::runtime_error("OpenGL 3.3 not supported, cannot use rasterization fallback");
+        }
+#ifdef USE_VULKAN_KOMPUTE
+        else if (tsne_type == COMPUTE_SHADER_VULKAN) {
           if (vulkan_supported) {
             _gpgpu_type = COMPUTE_SHADER_VULKAN;
           } else {
@@ -116,13 +133,7 @@ namespace hdi {
           #endif
           }
         }
-        else if (tsne_type == COMPUTE_SHADER && !glV43_supported) {
-          std::cout << "OpenGL 4.3 not supported, using rasterization fallback" << std::endl;
-          _gpgpu_type = RASTER;
-        }
-        else if (tsne_type == RASTER && !glV33_supported) {
-          throw std::runtime_error("OpenGL 3.3 not supported, cannot use rasterization fallback");
-        }
+#endif
         else
         {
           _gpgpu_type = tsne_type;
@@ -135,8 +146,10 @@ namespace hdi {
 
     void GradientDescentTSNETexture::clear() {
       _embedding->clear();
+#ifdef USE_VULKAN_KOMPUTE
       if (_gpgpu_type == COMPUTE_SHADER_VULKAN)
         _gpgpu_vulkan_compute_tsne.clean();
+#endif
       _initialized = false;
     }
 
@@ -182,14 +195,15 @@ namespace hdi {
         _gpgpu_compute_tsne.initialize(_embedding, _params, _P);
       else {
 #endif
+#ifdef USE_VULKAN_KOMPUTE
         if (_gpgpu_type == COMPUTE_SHADER_VULKAN)
           _gpgpu_vulkan_compute_tsne.initialize(_embedding, _params, _P);
         else// (_tsne_type == RASTER)
+#endif
           _gpgpu_raster_tsne.initialize(_embedding, _params, _P);
 #ifndef __APPLE__
       }
 #endif
-
 
       _iteration = 0;
 
@@ -224,13 +238,12 @@ namespace hdi {
         _gpgpu_compute_tsne.initialize(_embedding, _params, _P);
       else
 #endif
+#ifdef USE_VULKAN_KOMPUTE
       if (_gpgpu_type == COMPUTE_SHADER_VULKAN)
         _gpgpu_vulkan_compute_tsne.initialize(_embedding, _params, _P);
       else// (_tsne_type == RASTER)
+#endif
         _gpgpu_raster_tsne.initialize(_embedding, _params, _P);
-//#else
-//      _gpgpu_raster_tsne.initialize(_embedding, _params, _P);
-//#endif
 
       _iteration = 0;
 
@@ -244,10 +257,12 @@ namespace hdi {
       }
       _params = params;
 
+#ifdef USE_VULKAN_KOMPUTE
       // vulkan is possible on any platform.
       if (_gpgpu_type == COMPUTE_SHADER_VULKAN)
         _gpgpu_vulkan_compute_tsne.updateParams(params);
       else
+#endif
 #ifndef __APPLE__ 
         if (_gpgpu_type == COMPUTE_SHADER)
           _gpgpu_compute_tsne.updateParams(params);
@@ -344,16 +359,17 @@ namespace hdi {
       }
       else
 #endif
+#ifdef USE_VULKAN_KOMPUTE
       if (_gpgpu_type == COMPUTE_SHADER_VULKAN) {
         _gpgpu_vulkan_compute_tsne.compute(_embedding, exaggerationFactor(), _iteration, mult);
         kl_divergence = _gpgpu_vulkan_compute_tsne.kl_divergence;
       }
-      else {
+      else 
+#endif
+      {
           _gpgpu_raster_tsne.compute(_embedding, exaggerationFactor(), _iteration, mult);
       }
-//#else
-//      _gpgpu_raster_tsne.compute(_embedding, exaggerationFactor(), _iteration, mult);
-//#endif
+
       ++_iteration;
     }
 


### PR DESCRIPTION
Currently, the HDILib provides the option to use vulkan bindings, but does not build when this option is set OFF.

This PR adds extends the already existing def-guards to handle the vulkan settings and apple setting (no compute shaders.)