### PR TITLE
Change HDILib_BUILD_EXAMPLE to cache variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ install
 out
 hdi/dimensionality_reduction/dr_config.h
 hdi/dimensionality_reduction/gpgpu_vulkan/shaders/*.hpp
+hdi/dimensionality_reduction/gpgpu_vulkan/shaders/config*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,8 +190,7 @@ add_subdirectory(hdi/dimensionality_reduction)
 # Example project
 # -----------------------------------------------------------------------------
 if(HDILib_BUILD_EXAMPLE)
-	message(STATUS "Build HDLIB test application at: ${CMAKE_CURRENT_SOURCE_DIR}/examples/cli_test_program")
-    add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/examples/cli_test_program")
+    add_subdirectory(examples/cli_test_program)
 endif()
 
 # -----------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,7 +199,7 @@ endif()
 # -----------------------------------------------------------------------------
 if(HDILib_BUILD_TESTS)
 	message(STATUS "Build HDLIB unit tests")
-	add_subdirectory("test")
+	add_subdirectory(test)
 endif()
 
 # -----------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,8 +190,8 @@ add_subdirectory(hdi/dimensionality_reduction)
 # Example project
 # -----------------------------------------------------------------------------
 if(HDILib_BUILD_EXAMPLE)
-	message(STATUS "Build HDLIB test application")
-    add_subdirectory(examples/cli_test_program)
+	message(STATUS "Build HDLIB test application at: ${CMAKE_CURRENT_SOURCE_DIR}/examples/cli_test_program")
+    add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/examples/cli_test_program")
 endif()
 
 # -----------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,7 @@ add_subdirectory(hdi/dimensionality_reduction)
 # Example project
 # -----------------------------------------------------------------------------
 if(HDILib_BUILD_EXAMPLE)
+    message(STATUS "Build HDLIB test application")
     add_subdirectory(examples/cli_test_program)
 endif()
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -46,13 +46,12 @@ class HDILibConan(ConanFile):
     # , "conanbuildinfo.txt", "conanbuildinfo_debug.cmake", "conanbuildinfo_release.cmake", "conanbuildinfo_multi.cmake"
     exports = (
         "hdi*",
-        "external*",
         "cmake*",
         "CMakeLists.txt",
         "LICENSE",
         "vcpkg.json",
         "vcpkg-overlays*",
-        "tests*",
+        "examples*",
     )
 
     def _get_python_cmake(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -175,7 +175,7 @@ class HDILibConan(ConanFile):
             omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
             tc.variables["OpenMP_ROOT"] = omp_prefix_path
 
-        tc.variables["HDILib_BUILD_EXAMPLE"] = "ON"
+        tc.cache_variables["HDILib_BUILD_EXAMPLE"] = True
 
         print("Call toolchain generate")
         tc.generate()

--- a/examples/cli_test_program/CMakeLists.txt
+++ b/examples/cli_test_program/CMakeLists.txt
@@ -120,7 +120,9 @@ endmacro()
 #message(STATUS "***********************************")
 target_include_directories(tsne_tester PRIVATE "${argparse_SOURCE_DIR}/include")
 target_include_directories(tsne_tester PRIVATE "${rapidcsv_SOURCE_DIR}/src")
-target_include_directories(tsne_tester PRIVATE "${CMAKE_SOURCE_DIR}")
+target_include_directories(tsne_tester PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+target_include_directories(tsne_tester PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../..")
+
 # Debug
 #message(STATUS "A. Test binary at ${CMAKE_CURRENT_BINARY_DIR}")
 #file(GLOB CURBINDIRFILES "${CMAKE_CURRENT_BINARY_DIR}/*")

--- a/examples/cli_test_program/CMakeLists.txt
+++ b/examples/cli_test_program/CMakeLists.txt
@@ -29,7 +29,7 @@ message(STATUS "rapidcsv at ${rapidcsv_SOURCE_DIR}")
 # If using RenderDoc (https://renderdoc.org) or XCode GPU debugging capturing
 # GPU calls is a powerful debugging tool for Vulkan
 option(TSNETESTER_GPUDEBUG_CAPTURE " Enable GPU debug capture for the test program (Windows or MacOS)" OFF)
-set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
 configure_file(tSNETester_config.h.in tSNETester_config.h)
 if(APPLE AND TSNETESTER_GPUDEBUG_CAPTURE)
     enable_language(OBJCXX)

--- a/examples/cli_test_program/CMakeLists.txt
+++ b/examples/cli_test_program/CMakeLists.txt
@@ -155,7 +155,6 @@ endforeach()
 #add_custom_command(TARGET tsne_tester PRE_LINK COMMAND nm ${CMAKE_BINARY_DIR}/hdi/data/$<CONFIG>/${CMAKE_STATIC_LIBRARY_PREFIX}hdidata${CMAKE_STATIC_LIBRARY_SUFFIX})
 #add_custom_command(TARGET tsne_tester PRE_LINK COMMAND nm ${CMAKE_BINARY_DIR}/hdi/utils/$<CONFIG>/${CMAKE_STATIC_LIBRARY_PREFIX}hdiutils${CMAKE_STATIC_LIBRARY_SUFFIX})
 
-message(STATUS "hdi data symbols ${HDIDATA_SYMBOLS}")
 # For static library linking the consumer lib comes first (gcc)
 target_link_libraries(tsne_tester PRIVATE Vulkan::Vulkan)
 target_link_libraries(tsne_tester PRIVATE glfw)

--- a/examples/cli_test_program/CMakeLists.txt
+++ b/examples/cli_test_program/CMakeLists.txt
@@ -129,15 +129,15 @@ file(GLOB_RECURSE ITEMS
     RELATIVE "${CMAKE_CURRENT_LIST_DIR}/../../"
     "${CMAKE_CURRENT_LIST_DIR}/../../hdi/*"
 )
-message(STATUS "ITEMS: ${ITEMS}")
+#message(STATUS "ITEMS: ${ITEMS}")
 
 file(GLOB_RECURSE ITEMS2
     "${CMAKE_CURRENT_LIST_DIR}/../../hdi/*"
 )
 
-foreach(item IN LISTS ITEMS2)
-    message(STATUS "${item}")
-endforeach()
+#foreach(item IN LISTS ITEMS2)
+#    message(STATUS "${item}")
+#endforeach()
 
 # Debug
 #message(STATUS "A. Test binary at ${CMAKE_CURRENT_BINARY_DIR}")

--- a/examples/cli_test_program/CMakeLists.txt
+++ b/examples/cli_test_program/CMakeLists.txt
@@ -14,7 +14,7 @@ FetchContent_Declare(
 
 )
 FetchContent_MakeAvailable(argparse)
-message(STATUS "hnswlib at ${argparse_SOURCE_DIR}")
+message(STATUS "argparse at ${argparse_SOURCE_DIR}")
 
 message (STATUS "Fetching rapidcsv...")
 FetchContent_Declare(
@@ -24,7 +24,7 @@ FetchContent_Declare(
   EXCLUDE_FROM_ALL
 )
 FetchContent_MakeAvailable(rapidcsv)
-message(STATUS "hnswlib at ${rapidcsv_SOURCE_DIR}")
+message(STATUS "rapidcsv at ${rapidcsv_SOURCE_DIR}")
 
 # If using RenderDoc (https://renderdoc.org) or XCode GPU debugging capturing
 # GPU calls is a powerful debugging tool for Vulkan

--- a/examples/cli_test_program/CMakeLists.txt
+++ b/examples/cli_test_program/CMakeLists.txt
@@ -159,9 +159,7 @@ file(GLOB_RECURSE ITEMS2
 target_link_libraries(tsne_tester PRIVATE Vulkan::Vulkan)
 target_link_libraries(tsne_tester PRIVATE glfw)
 target_link_libraries(tsne_tester PRIVATE ${OPENGL_LIBRARIES})
-target_link_libraries(tsne_tester PRIVATE ${CMAKE_BINARY_DIR}/hdi/dimensionality_reduction/$<CONFIG>/${CMAKE_STATIC_LIBRARY_PREFIX}hdidimensionalityreduction${CMAKE_STATIC_LIBRARY_SUFFIX})
-target_link_libraries(tsne_tester PRIVATE ${CMAKE_BINARY_DIR}/hdi/utils/$<CONFIG>/${CMAKE_STATIC_LIBRARY_PREFIX}hdiutils${CMAKE_STATIC_LIBRARY_SUFFIX})
-target_link_libraries(tsne_tester PRIVATE ${CMAKE_BINARY_DIR}/hdi/data/$<CONFIG>/${CMAKE_STATIC_LIBRARY_PREFIX}hdidata${CMAKE_STATIC_LIBRARY_SUFFIX})
+target_link_libraries(tsne_tester PRIVATE hdidimensionalityreduction hdiutils hdidata)
 target_link_libraries(tsne_tester PRIVATE kompute::kompute)
 
 if (APPLE)

--- a/examples/cli_test_program/CMakeLists.txt
+++ b/examples/cli_test_program/CMakeLists.txt
@@ -120,8 +120,24 @@ endmacro()
 #message(STATUS "***********************************")
 target_include_directories(tsne_tester PRIVATE "${argparse_SOURCE_DIR}/include")
 target_include_directories(tsne_tester PRIVATE "${rapidcsv_SOURCE_DIR}/src")
-target_include_directories(tsne_tester PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
-target_include_directories(tsne_tester PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../..")
+target_include_directories(tsne_tester PRIVATE "${CMAKE_CURRENT_LIST_DIR}")
+target_include_directories(tsne_tester PRIVATE "${CMAKE_CURRENT_LIST_DIR}/../..")
+
+message(STATUS "CMAKE_CURRENT_LIST_DIR: ${CMAKE_CURRENT_LIST_DIR}")
+
+file(GLOB_RECURSE ITEMS 
+    RELATIVE "${CMAKE_CURRENT_LIST_DIR}/../../"
+    "${CMAKE_CURRENT_LIST_DIR}/../../hdi/*"
+)
+message(STATUS "ITEMS: ${ITEMS}")
+
+file(GLOB_RECURSE ITEMS2
+    "${CMAKE_CURRENT_LIST_DIR}/../../hdi/*"
+)
+
+foreach(item IN LISTS ITEMS2)
+    message(STATUS "${item}")
+endforeach()
 
 # Debug
 #message(STATUS "A. Test binary at ${CMAKE_CURRENT_BINARY_DIR}")

--- a/examples/cli_test_program/CMakeLists.txt
+++ b/examples/cli_test_program/CMakeLists.txt
@@ -123,22 +123,6 @@ target_include_directories(tsne_tester PRIVATE "${rapidcsv_SOURCE_DIR}/src")
 target_include_directories(tsne_tester PRIVATE "${CMAKE_CURRENT_LIST_DIR}")
 target_include_directories(tsne_tester PRIVATE "${CMAKE_CURRENT_LIST_DIR}/../..")
 
-message(STATUS "CMAKE_CURRENT_LIST_DIR: ${CMAKE_CURRENT_LIST_DIR}")
-
-file(GLOB_RECURSE ITEMS 
-    RELATIVE "${CMAKE_CURRENT_LIST_DIR}/../../"
-    "${CMAKE_CURRENT_LIST_DIR}/../../hdi/*"
-)
-#message(STATUS "ITEMS: ${ITEMS}")
-
-file(GLOB_RECURSE ITEMS2
-    "${CMAKE_CURRENT_LIST_DIR}/../../hdi/*"
-)
-
-#foreach(item IN LISTS ITEMS2)
-#    message(STATUS "${item}")
-#endforeach()
-
 # Debug
 #message(STATUS "A. Test binary at ${CMAKE_CURRENT_BINARY_DIR}")
 #file(GLOB CURBINDIRFILES "${CMAKE_CURRENT_BINARY_DIR}/*")

--- a/examples/cli_test_program/tSNETester.cpp
+++ b/examples/cli_test_program/tSNETester.cpp
@@ -11,13 +11,9 @@
 #endif
 
 
-#include "hdi/utils/cout_log.h"
 #include "hdi/utils/glad/glad.h"
 #include "hdi/dimensionality_reduction/knn_utils.h"
-#include "hdi/utils/log_helper_functions.h"
 #include "hdi/data/embedding.h"
-#include "hdi/data/panel_data.h"
-#include "hdi/data/io.h"
 #include "hdi/dimensionality_reduction/hd_joint_probability_generator.h"
 #include "hdi/dimensionality_reduction/gradient_descent_tsne_texture.h"
 #include "hdi/utils/scoped_timers.h"

--- a/hdi/dimensionality_reduction/CMakeLists.txt
+++ b/hdi/dimensionality_reduction/CMakeLists.txt
@@ -98,9 +98,9 @@ if(HDILib_USE_VULKAN_KOMPUTE)
     source_group(ShadersVulkan FILES ${ShaderFilesVulkan})
     message(STATUS "Add vulkan subdir")
     add_subdirectory(gpgpu_vulkan)
-    message(STATUS "CMAKE_CURRENT_LIST_DIR: ${CMAKE_CURRENT_LIST_DIR}")
+    message(STATUS "CMAKE_CURRENT_SOURCE_DIR: ${CMAKE_CURRENT_SOURCE_DIR}")
     # Sanity check that the generated headers align with our list above
-    file(GLOB GENERATED_VULKAN_SHADER_HEADERS RELATIVE ${CMAKE_CURRENT_LIST_DIR}
+    file(GLOB GENERATED_VULKAN_SHADER_HEADERS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
         "gpgpu_vulkan/shaders/*.hpp"
     )
     set(_lhs "${GENERATED_VULKAN_SHADER_HEADERS}")

--- a/hdi/dimensionality_reduction/CMakeLists.txt
+++ b/hdi/dimensionality_reduction/CMakeLists.txt
@@ -95,9 +95,26 @@ if(HDILib_USE_VULKAN_KOMPUTE)
       list(APPEND HeaderFilesVulkan "gpgpu_vulkan/shaders/${_COMP_ROOT}.hpp")
     endforeach()
     
-    source_group(Shaders FILES ${ShaderFilesVulkan})
+    source_group(ShadersVulkan FILES ${ShaderFilesVulkan})
     message(STATUS "Add vulkan subdir")
     add_subdirectory(gpgpu_vulkan)
+    message(STATUS "CMAKE_CURRENT_LIST_DIR: ${CMAKE_CURRENT_LIST_DIR}")
+    # Sanity check that the generated headers align with our list above
+    file(GLOB GENERATED_VULKAN_SHADER_HEADERS RELATIVE ${CMAKE_CURRENT_LIST_DIR}
+        "gpgpu_vulkan/shaders/*.hpp"
+    )
+    set(_lhs "${GENERATED_VULKAN_SHADER_HEADERS}")
+    set(_rhs "${HeaderFilesVulkan}")
+    list(SORT _lhs)
+    list(SORT _rhs)
+    if(NOT _lhs STREQUAL _rhs)
+    message(WARNING
+        "GENERATED_VULKAN_SHADER_HEADERS does not match HeaderFilesVulkan\n"
+        "GENERATED_VULKAN_SHADER_HEADERS = ${_lhs}\n"
+        "HeaderFilesVulkan               = ${_rhs}"
+    )
+    endif()
+    
 endif()
 
 add_library(${PROJECT_DR} STATIC ${HeaderFilesDR} ${SourceFilesDR} ${ShaderFilesVulkan})
@@ -105,8 +122,6 @@ add_library(${PROJECT_DR} STATIC ${HeaderFilesDR} ${SourceFilesDR} ${ShaderFiles
 target_include_directories(${PROJECT_DR} PRIVATE "${PROJECT_SOURCE_DIR}")
 target_include_directories(${PROJECT_DR} PRIVATE "${hnswlib_SOURCE_DIR}")
 target_include_directories(${PROJECT_DR} PRIVATE "${Annoy_SOURCE_DIR}")
-#include the generated dr_config.h file and any others
-target_include_directories(${PROJECT_DR} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 # prefer static linking
 if(NOT FLANN_TARGET)

--- a/hdi/dimensionality_reduction/CMakeLists.txt
+++ b/hdi/dimensionality_reduction/CMakeLists.txt
@@ -98,23 +98,6 @@ if(HDILib_USE_VULKAN_KOMPUTE)
     source_group(ShadersVulkan FILES ${ShaderFilesVulkan})
     message(STATUS "Add vulkan subdir")
     add_subdirectory(gpgpu_vulkan)
-    message(STATUS "CMAKE_CURRENT_SOURCE_DIR: ${CMAKE_CURRENT_SOURCE_DIR}")
-    # Sanity check that the generated headers align with our list above
-    file(GLOB GENERATED_VULKAN_SHADER_HEADERS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
-        "gpgpu_vulkan/shaders/*.hpp"
-    )
-    set(_lhs "${GENERATED_VULKAN_SHADER_HEADERS}")
-    set(_rhs "${HeaderFilesVulkan}")
-    list(SORT _lhs)
-    list(SORT _rhs)
-    if(NOT _lhs STREQUAL _rhs)
-    message(WARNING
-        "GENERATED_VULKAN_SHADER_HEADERS does not match HeaderFilesVulkan\n"
-        "GENERATED_VULKAN_SHADER_HEADERS = ${_lhs}\n"
-        "HeaderFilesVulkan               = ${_rhs}"
-    )
-    endif()
-    
 endif()
 
 add_library(${PROJECT_DR} STATIC ${HeaderFilesDR} ${SourceFilesDR} ${ShaderFilesVulkan})

--- a/hdi/dimensionality_reduction/gpgpu_sne/field_computation.cpp
+++ b/hdi/dimensionality_reduction/gpgpu_sne/field_computation.cpp
@@ -1,4 +1,4 @@
-#include "field_computation.h"
+#include "hdi/dimensionality_reduction/gpgpu_sne/field_computation.h"
 
 #include <cmath>
 #include <vector>

--- a/hdi/dimensionality_reduction/gpgpu_sne/gpgpu_sne_compute.h
+++ b/hdi/dimensionality_reduction/gpgpu_sne/gpgpu_sne_compute.h
@@ -37,7 +37,7 @@
 #include "hdi/data/embedding.h"
 #include "hdi/data/map_mem_eff.h"
 #include "hdi/dimensionality_reduction/tsne_parameters.h"
-#include "field_computation.h"
+#include "hdi/dimensionality_reduction/gpgpu_sne/field_computation.h"
 
 #include <array>
 #include <cstdint>

--- a/hdi/dimensionality_reduction/gpgpu_vulkan/gpgpu_sne_comp_vulkan.cpp
+++ b/hdi/dimensionality_reduction/gpgpu_vulkan/gpgpu_sne_comp_vulkan.cpp
@@ -1,4 +1,4 @@
-#include "gpgpu_sne_comp_vulkan.h"
+#include "hdi/dimensionality_reduction/gpgpu_vulkan/gpgpu_sne_comp_vulkan.h"
 
 #include <vector>
 #include <limits> 

--- a/hdi/dimensionality_reduction/gpgpu_vulkan/gpgpu_sne_comp_vulkan.h
+++ b/hdi/dimensionality_reduction/gpgpu_vulkan/gpgpu_sne_comp_vulkan.h
@@ -8,8 +8,8 @@
 #include "hdi/data/embedding.h"
 #include "hdi/data/map_mem_eff.h"
 #include "hdi/dimensionality_reduction/tsne_parameters.h"
-#include "tensor_config.h"
-#include "shaders/shader_progs.h"
+#include "hdi/dimensionality_reduction/gpgpu_vulkan/tensor_config.h"
+#include "hdi/dimensionality_reduction/gpgpu_vulkan/shaders/shader_progs.h"
 
 #include <kompute/Kompute.hpp>
 #include <memory>

--- a/hdi/dimensionality_reduction/gpgpu_vulkan/shaders/CMakeLists.txt
+++ b/hdi/dimensionality_reduction/gpgpu_vulkan/shaders/CMakeLists.txt
@@ -4,6 +4,8 @@
 set_property(GLOBAL PROPERTY
     VULKAN_COMPILE_SHADER_CWD_PROPERTY "${CMAKE_CURRENT_LIST_DIR}")
 
+message(STATUS "VULKAN_COMPILE_SHADER_CWD_PROPERTY: ${VULKAN_COMPILE_SHADER_CWD_PROPERTY}")
+
 function(vulkan_compile_shader_13)
      find_program(GLS_LANG_VALIDATOR_PATH NAMES glslangValidator)
      if(GLS_LANG_VALIDATOR_PATH STREQUAL "GLS_LANG_VALIDATOR_PATH-NOTFOUND")
@@ -48,7 +50,12 @@ function(vulkan_compile_shader_13)
              add_custom_target(build-time-make-directory-${SHADER_COMPILE_SPV_FILENAME} ALL
              COMMAND ${CMAKE_COMMAND} -E make_directory ${SHADER_COMPILE_SPV_PATH})
      endif()
-
+    
+    message(STATUS "VULKAN_COMPILE_SHADER_CWD: ${VULKAN_COMPILE_SHADER_CWD}")
+    message(STATUS "SHADER_COMPILE_SPV_FILE_FULL: ${SHADER_COMPILE_SPV_FILE_FULL}")
+    message(STATUS "SHADER_COMPILE_HEADER_FILE_FULL: ${SHADER_COMPILE_HEADER_FILE_FULL}")
+    message(STATUS "SHADER_COMPILE_NAMESPACE: ${SHADER_COMPILE_NAMESPACE}")
+    
      ## Requires custom command function as this is the only way to call 
      ## a function during compile time from cmake (ie through cmake script)
      add_custom_command(OUTPUT "${SHADER_COMPILE_HEADER_FILE_FULL}"
@@ -63,6 +70,9 @@ function(vulkan_compile_shader_13)
                         COMMENT "Converting compiled shader '${SHADER_COMPILE_SPV_FILE_FULL}' to header file '${SHADER_COMPILE_HEADER_FILE_FULL}'."
                         MAIN_DEPENDENCY "${SHADER_COMPILE_SPV_FILE_FULL}")
 endfunction()
+
+message(STATUS "CMAKE_CURRENT_SOURCE_DIR: ${CMAKE_CURRENT_SOURCE_DIR}")
+message(STATUS "CMAKE_CURRENT_LIST_DIR: ${CMAKE_CURRENT_LIST_DIR}")
 
 file(GLOB COMP_FILES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.comp)
 find_package(kompute CONFIG REQUIRED) # imports the vulkan compiler

--- a/hdi/dimensionality_reduction/gpgpu_vulkan/shaders/CMakeLists.txt
+++ b/hdi/dimensionality_reduction/gpgpu_vulkan/shaders/CMakeLists.txt
@@ -66,16 +66,16 @@ endfunction()
 
 file(GLOB COMP_FILES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.comp)
 find_package(kompute CONFIG REQUIRED) # imports the vulkan compiler
-set(_shader_hpp_list)
+set(_shader_hpp_list "")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/shader_defines.glsl.in
                ${CMAKE_CURRENT_SOURCE_DIR}/config/shader_defines.glsl @ONLY)
-foreach(_shader ${COMP_FILES})
-    string(REPLACE ".comp" ".hpp" _shader_hpp ${_shader})
-    get_filename_component(_namespace ${_shader} NAME_WE)
-    message(STATUS "Vulkan shader ${_shader} to ${_shader_hpp} with namespace ${_namespace}")
+foreach(_shader_comp ${COMP_FILES})
+    string(REPLACE ".comp" ".hpp" _shader_hpp ${_shader_comp})
+    get_filename_component(_namespace ${_shader_comp} NAME_WE)
+    message(STATUS "Vulkan shader ${_shader_comp} to ${_shader_hpp} with namespace ${_namespace}")
     list(APPEND _shader_hpp_list "${_shader_hpp}")
     vulkan_compile_shader_13(
-        INFILE ${_shader}
+        INFILE ${_shader_comp}
         OUTFILE ${_shader_hpp}
         NAMESPACE ${_namespace}
     )   

--- a/hdi/dimensionality_reduction/gpgpu_vulkan/shaders/CMakeLists.txt
+++ b/hdi/dimensionality_reduction/gpgpu_vulkan/shaders/CMakeLists.txt
@@ -4,8 +4,6 @@
 set_property(GLOBAL PROPERTY
     VULKAN_COMPILE_SHADER_CWD_PROPERTY "${CMAKE_CURRENT_LIST_DIR}")
 
-message(STATUS "VULKAN_COMPILE_SHADER_CWD_PROPERTY: ${VULKAN_COMPILE_SHADER_CWD_PROPERTY}")
-
 function(vulkan_compile_shader_13)
      find_program(GLS_LANG_VALIDATOR_PATH NAMES glslangValidator)
      if(GLS_LANG_VALIDATOR_PATH STREQUAL "GLS_LANG_VALIDATOR_PATH-NOTFOUND")
@@ -50,12 +48,7 @@ function(vulkan_compile_shader_13)
              add_custom_target(build-time-make-directory-${SHADER_COMPILE_SPV_FILENAME} ALL
              COMMAND ${CMAKE_COMMAND} -E make_directory ${SHADER_COMPILE_SPV_PATH})
      endif()
-    
-    message(STATUS "VULKAN_COMPILE_SHADER_CWD: ${VULKAN_COMPILE_SHADER_CWD}")
-    message(STATUS "SHADER_COMPILE_SPV_FILE_FULL: ${SHADER_COMPILE_SPV_FILE_FULL}")
-    message(STATUS "SHADER_COMPILE_HEADER_FILE_FULL: ${SHADER_COMPILE_HEADER_FILE_FULL}")
-    message(STATUS "SHADER_COMPILE_NAMESPACE: ${SHADER_COMPILE_NAMESPACE}")
-    
+        
      ## Requires custom command function as this is the only way to call 
      ## a function during compile time from cmake (ie through cmake script)
      add_custom_command(OUTPUT "${SHADER_COMPILE_HEADER_FILE_FULL}"
@@ -70,9 +63,6 @@ function(vulkan_compile_shader_13)
                         COMMENT "Converting compiled shader '${SHADER_COMPILE_SPV_FILE_FULL}' to header file '${SHADER_COMPILE_HEADER_FILE_FULL}'."
                         MAIN_DEPENDENCY "${SHADER_COMPILE_SPV_FILE_FULL}")
 endfunction()
-
-message(STATUS "CMAKE_CURRENT_SOURCE_DIR: ${CMAKE_CURRENT_SOURCE_DIR}")
-message(STATUS "CMAKE_CURRENT_LIST_DIR: ${CMAKE_CURRENT_LIST_DIR}")
 
 file(GLOB COMP_FILES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.comp)
 find_package(kompute CONFIG REQUIRED) # imports the vulkan compiler

--- a/hdi/dimensionality_reduction/gpgpu_vulkan/shaders/config/shader_defines.glsl
+++ b/hdi/dimensionality_reduction/gpgpu_vulkan/shaders/config/shader_defines.glsl
@@ -1,1 +1,0 @@
-#define SHADER_USE_PUSH_CONSTANTS @@

--- a/hdi/dimensionality_reduction/gpgpu_vulkan/shaders/shader_progs.h
+++ b/hdi/dimensionality_reduction/gpgpu_vulkan/shaders/shader_progs.h
@@ -1,10 +1,12 @@
 #pragma once
-#include "shaders.h"
-#include "../tensor_config.h"
+
+#include "hdi/dimensionality_reduction/gpgpu_vulkan/shaders/shaders.h"
+#include "hdi/dimensionality_reduction/gpgpu_vulkan/shaders/vkUniformBufferHelper.h"
+#include "hdi/dimensionality_reduction/gpgpu_vulkan/tensor_config.h"
+
 #include <kompute/Kompute.hpp>
 #include <memory>
 #include <vector>
-#include "vkUniformBufferHelper.h"
 
 class ShaderImageHelper {
   public:

--- a/hdi/dimensionality_reduction/gpgpu_vulkan/shaders/shaders.h
+++ b/hdi/dimensionality_reduction/gpgpu_vulkan/shaders/shaders.h
@@ -1,19 +1,21 @@
 #pragma once
+
 #include <map>
 #include <vector>
-#include "bounds.hpp"
-#include "compute_fields.hpp"
-#include "compute_fields_enh.hpp"
-#include "compute_forces.hpp"
-#include "interp_fields.hpp" 
-#include "interp1.hpp"
-#include "interp2.hpp"
-#include "stencil.hpp"
-#include "reset_counter.hpp"
-#include "stencil2active.hpp"
-#include "compute_field_workgroup.hpp"
-#include "update.hpp"   
-#include "center_scale.hpp"
+
+#include "hdi/dimensionality_reduction/gpgpu_vulkan/shaders/bounds.hpp"
+#include "hdi/dimensionality_reduction/gpgpu_vulkan/shaders/compute_fields.hpp"
+#include "hdi/dimensionality_reduction/gpgpu_vulkan/shaders/compute_fields_enh.hpp"
+#include "hdi/dimensionality_reduction/gpgpu_vulkan/shaders/compute_forces.hpp"
+#include "hdi/dimensionality_reduction/gpgpu_vulkan/shaders/interp_fields.hpp"
+#include "hdi/dimensionality_reduction/gpgpu_vulkan/shaders/interp1.hpp"
+#include "hdi/dimensionality_reduction/gpgpu_vulkan/shaders/interp2.hpp"
+#include "hdi/dimensionality_reduction/gpgpu_vulkan/shaders/stencil.hpp"
+#include "hdi/dimensionality_reduction/gpgpu_vulkan/shaders/reset_counter.hpp"
+#include "hdi/dimensionality_reduction/gpgpu_vulkan/shaders/stencil2active.hpp"
+#include "hdi/dimensionality_reduction/gpgpu_vulkan/shaders/compute_field_workgroup.hpp"
+#include "hdi/dimensionality_reduction/gpgpu_vulkan/shaders/update.hpp"
+#include "hdi/dimensionality_reduction/gpgpu_vulkan/shaders/center_scale.hpp"
 
 enum class SPIRVShader {
   BOUNDS = 0,

--- a/hdi/dimensionality_reduction/gpgpu_vulkan/shaders/vulkan_extension.cpp
+++ b/hdi/dimensionality_reduction/gpgpu_vulkan/shaders/vulkan_extension.cpp
@@ -1,4 +1,4 @@
-#include "vulkan_extension.h"
+#include "hdi/dimensionality_reduction/gpgpu_vulkan/shaders/vulkan_extension.h"
 
 // record() will be called by kp::Sequence with a vk::CommandBuffer
 void OpIndirectDispatch::record(const vk::CommandBuffer& commandBuffer) {


### PR DESCRIPTION
`tc.variables[...]` sets a normal CMake variable but `HDILib_BUILD_EXAMPLE` is a CMake option and option() initializes from the cache, not a regular variable. Now we actually build the test program on the CI again, which was broken since https://github.com/biovault/HDILib/pull/64.

Also:
- Copy `examples` folder to recipe instead of previously used `tests` folder
- Do not track generated file
- Make `tsne_tester` explicitly dependent on HDILib which will force the build order to be correct
- Use more full include path