### PR TITLE
Add vcpkg binary cache setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,8 +124,14 @@ jobs:
         env:
           VCPKG_BINARY_SOURCES: default,rw
 
-      - name: Set vcpkg directory
+      - name: Set vcpkg directory (Unix)
+        if: "!startsWith(runner.os, 'Windows')"
         run: echo "VCPKG_LUKKA_DIR=${{ runner.temp }}/vcpkg" >> $GITHUB_ENV
+
+      - name: Set vcpkg directory (Windows)
+        if: startsWith(runner.os, 'Windows')
+        shell: pwsh
+        run: echo "VCPKG_LUKKA_DIR=${{ runner.temp }}/vcpkg" >> $env:GITHUB_ENV
 
       - name: Windows build
         if: startsWith(matrix.os, 'Windows')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -195,11 +195,9 @@ jobs:
       - name: Set up binary cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
-          key: ${{ runner.os }}-vcpkg-binary-cache-${{ hashFiles('vcpkg*.json') }}
-          restore-keys: |
-            ${{ runner.os }}-vcpkg-binary-cache-
-
+          path: msvc-full-features/vcpkg_installed
+          key: vcpkg-installed-${{ hashFiles('msvc-full-features/vcpkg.json', '.github/vcpkg_triplets/x64-windows-static.cmake') }}-c3867e714dd3a51c272826eea77267876517ed99
+  
       - name: Linux build
         uses: ./.github/conan_linuxmac_build
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,16 +94,16 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Select Xcode for Mac only
-        if: startsWith(runner.os, 'macOS')
-        run: |
-          sudo xcode-select -switch /Applications/Xcode_${{matrix.build-xcode-version}}.app
-
       - name: Setup python version
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           
+      - name: Select Xcode for Mac only
+        if: startsWith(runner.os, 'macOS')
+        run: |
+          sudo xcode-select -switch /Applications/Xcode_${{matrix.build-xcode-version}}.app
+
       - name: Set vcpkg environment (Unix)
         if: "!startsWith(runner.os, 'Windows')"
         run: |
@@ -203,16 +203,10 @@ jobs:
           submodules: recursive
           set-safe-directory: true
 
-      - name: Verify default Python installation
-        run: |
-          python3 --version
-          python3 -m ensurepip --upgrade
-          pip3 --version
-  
-      - name: Verify Python installation
-        run: |
-          python3 --version
-          pip3 --version
+      - name: Setup python version
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
 
       # Ensure zip is available on manylinux before vcpkg setup
       - name: Install zip
@@ -220,26 +214,26 @@ jobs:
         run: |
           dnf install -y zip
 
-      - name: Set vcpkg environment
+      - name: Set vcpkg environment (Unix)
         run: |
           echo "VCPKG_DIR=${{ runner.temp }}/vcpkg" >> $GITHUB_ENV
           echo "VCPKG_ROOT=${{ runner.temp }}/vcpkg" >> $GITHUB_ENV
           echo "VCPKG_BINARY_SOURCES=clear;files,${{ runner.temp }}/vcpkg-cache,readwrite" >> $GITHUB_ENV
-          
+
       - name: Set up binary cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ runner.temp }}/vcpkg-cache
-          key: vcpkg-cache-${{ runner.os }}-${{ hashFiles('**/vcpkg.json', 'vcpkg-overlays/**') }}
+          key: vcpkg-cache-${{ runner.os }}-${{ env.VCPKG_COMMIT_SHA }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-overlays/**') }}
           restore-keys: |
-            vcpkg-cache-${{ runner.os }}-
-
+            vcpkg-cache-${{ runner.os }}-${{ env.VCPKG_COMMIT_SHA }}
+  
       - name: Clone and checkout vcpkg
         run: |
           git clone https://github.com/microsoft/vcpkg.git --branch master ${{ env.VCPKG_DIR }}
           git -C ${{ env.VCPKG_DIR }} checkout ${{ env.VCPKG_COMMIT_SHA }}
 
-      - name: Bootstrap vcpkg (Unix)
+      - name: Bootstrap vcpkg
         run: ${{ env.VCPKG_DIR }}/bootstrap-vcpkg.sh -disableMetrics
           
       - name: Linux build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,8 +129,7 @@ jobs:
   
       - name: Clone and checkout vcpkg
         run: |
-          git clone --depth 1 https://github.com/microsoft/vcpkg.git --branch master ${{ env.VCPKG_DIR }}
-          git -C ${{ env.VCPKG_DIR }} fetch --depth 1 origin ${{ env.VCPKG_COMMIT_SHA }}
+          git clone https://github.com/microsoft/vcpkg.git --branch master ${{ env.VCPKG_DIR }}
           git -C ${{ env.VCPKG_DIR }} checkout ${{ env.VCPKG_COMMIT_SHA }}
 
       - name: Bootstrap vcpkg (Unix)
@@ -237,8 +236,7 @@ jobs:
 
       - name: Clone and checkout vcpkg
         run: |
-          git clone --depth 1 https://github.com/microsoft/vcpkg.git --branch master ${{ env.VCPKG_DIR }}
-          git -C ${{ env.VCPKG_DIR }} fetch --depth 1 origin ${{ env.VCPKG_COMMIT_SHA }}
+          git clone https://github.com/microsoft/vcpkg.git --branch master ${{ env.VCPKG_DIR }}
           git -C ${{ env.VCPKG_DIR }} checkout ${{ env.VCPKG_COMMIT_SHA }}
 
       - name: Bootstrap vcpkg (Unix)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,6 +184,18 @@ jobs:
         run: |
           dnf install -y zip
 
+      - name: Configure vcpkg binary caching
+        run: echo "VCPKG_BINARY_SOURCES=clear;files,${{ runner.temp }}/vcpkg-cache,readwrite" >> $GITHUB_ENV
+          
+      # Workaround for run-vcpkg cache instability: persist vcpkg binaries/downloads between jobs.
+      - name: Set up binary cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ runner.temp }}/vcpkg-cache
+          key: vcpkg-cache${{ runner.os }}-${{ hashFiles('**/vcpkg.json', 'vcpkg-overlays/**') }}
+          restore-keys: |
+            vcpkg-cache-${{ runner.os }}-
+  
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.6
         with: 
@@ -191,14 +203,7 @@ jobs:
           vcpkgDirectory: ${{ runner.temp }}/vcpkg
         env:
           VCPKG_BINARY_SOURCES: default,rw
-
-      # Workaround for run-vcpkg cache instability: persist vcpkg binaries/downloads between jobs.
-      - name: Set up binary cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: msvc-full-features/vcpkg_installed
-          key: vcpkg-installed-${{ hashFiles('vcpkg.json', 'vcpkg_overlays/**') }}-c3867e714dd3a51c272826eea77267876517ed99
-  
+          
       - name: Linux build
         uses: ./.github/conan_linuxmac_build
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,6 @@ on:
   workflow_dispatch:
 
 env:
-  VCPKG_DIR: ${{ runner.temp }}/vcpkg
-  VCPKG_BINARY_SOURCES: "clear;files,${{ runner.temp }}/vcpkg-cache,readwrite"
   VCPKG_COMMIT_SHA: c3867e714dd3a51c272826eea77267876517ed99 # corresponds to tag 2026.03.18
 
 # for matrix check https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners
@@ -106,21 +104,34 @@ jobs:
         with:
           python-version: "3.11"
           
-      # Workaround for run-vcpkg cache instability: persist vcpkg binaries/downloads between jobs.
+      - name: Set vcpkg environment (Unix)
+        if: "!startsWith(runner.os, 'Windows')"
+        run: |
+          echo "VCPKG_DIR=${{ runner.temp }}/vcpkg" >> $GITHUB_ENV
+          echo "VCPKG_ROOT=${{ runner.temp }}/vcpkg" >> $GITHUB_ENV
+          echo "VCPKG_BINARY_SOURCES=clear;files,${{ runner.temp }}/vcpkg-cache,readwrite" >> $GITHUB_ENV
+
+      - name: Set vcpkg environmentg (Windows)
+        if: startsWith(runner.os, 'Windows')
+        shell: pwsh
+        run: |
+          echo "VCPKG_DIR=${{ runner.temp }}/vcpkg" >> $env:GITHUB_ENV
+          echo "VCPKG_ROOT=${{ runner.temp }}/vcpkg" >> $env:GITHUB_ENV
+          echo "VCPKG_BINARY_SOURCES=clear;files,${{ runner.temp }}/vcpkg-cache,readwrite" >> $env:GITHUB_ENV
+
       - name: Set up binary cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ runner.temp }}/vcpkg-cache
-          key: vcpkg-cache-${{ runner.os }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-overlays/**') }}
+          key: vcpkg-cache-${{ runner.os }}-${{ env.VCPKG_COMMIT_SHA }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-overlays/**') }}
           restore-keys: |
-            vcpkg-cache-${{ runner.os }}-
+            vcpkg-cache-${{ runner.os }}-${{ env.VCPKG_COMMIT_SHA }}
   
-      - name: Clone vcpkg
-        run: git clone https://github.com/microsoft/vcpkg.git ${{ env.VCPKG_DIR }}
-
-      - name: Checkout vcpkg commit
-        working-directory: ${{ env.VCPKG_DIR }}
-        run: git checkout ${{ env.VCPKG_COMMIT_SHA }} # corresponds to tag 2026.03.18
+      - name: Clone and checkout vcpkg
+        run: |
+          git clone --depth 1 https://github.com/microsoft/vcpkg.git --branch master ${{ env.VCPKG_DIR }}
+          git -C ${{ env.VCPKG_DIR }} fetch --depth 1 origin ${{ env.VCPKG_COMMIT_SHA }}
+          git -C ${{ env.VCPKG_DIR }} checkout ${{ env.VCPKG_COMMIT_SHA }}
 
       - name: Bootstrap vcpkg (Unix)
         if: "!startsWith(runner.os, 'Windows')"
@@ -129,7 +140,7 @@ jobs:
       - name: Bootstrap vcpkg (Windows)
         if: startsWith(runner.os, 'Windows')
         shell: pwsh
-        run: ${{ env.VCPKG_DIR }}/bootstrap-vcpkg.bat -disableMetrics.
+        run: ${{ env.VCPKG_DIR }}/bootstrap-vcpkg.bat -disableMetrics
   
       - name: Windows build
         if: startsWith(matrix.os, 'Windows')
@@ -210,7 +221,12 @@ jobs:
         run: |
           dnf install -y zip
 
-      # Workaround for run-vcpkg cache instability: persist vcpkg binaries/downloads between jobs.
+      - name: Set vcpkg environment
+        run: |
+          echo "VCPKG_DIR=${{ runner.temp }}/vcpkg" >> $GITHUB_ENV
+          echo "VCPKG_ROOT=${{ runner.temp }}/vcpkg" >> $GITHUB_ENV
+          echo "VCPKG_BINARY_SOURCES=clear;files,${{ runner.temp }}/vcpkg-cache,readwrite" >> $GITHUB_ENV
+          
       - name: Set up binary cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -219,21 +235,14 @@ jobs:
           restore-keys: |
             vcpkg-cache-${{ runner.os }}-
 
-      - name: Clone vcpkg
-        run: git clone https://github.com/microsoft/vcpkg.git ${{ env.VCPKG_DIR }}
-
-      - name: Checkout vcpkg commit
-        working-directory: ${{ env.VCPKG_DIR }}
-        run: git checkout ${{ env.VCPKG_COMMIT_SHA }}
+      - name: Clone and checkout vcpkg
+        run: |
+          git clone --depth 1 https://github.com/microsoft/vcpkg.git --branch master ${{ env.VCPKG_DIR }}
+          git -C ${{ env.VCPKG_DIR }} fetch --depth 1 origin ${{ env.VCPKG_COMMIT_SHA }}
+          git -C ${{ env.VCPKG_DIR }} checkout ${{ env.VCPKG_COMMIT_SHA }}
 
       - name: Bootstrap vcpkg (Unix)
-        if: "!startsWith(runner.os, 'Windows')"
         run: ${{ env.VCPKG_DIR }}/bootstrap-vcpkg.sh -disableMetrics
-
-      - name: Bootstrap vcpkg (Windows)
-        if: startsWith(runner.os, 'Windows')
-        shell: pwsh
-        run: ${{ env.VCPKG_DIR }}/bootstrap-vcpkg.bat -disableMetrics.
           
       - name: Linux build
         uses: ./.github/conan_linuxmac_build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,11 +192,12 @@ jobs:
         env:
           VCPKG_BINARY_SOURCES: default,rw
 
+      # Workaround for run-vcpkg cache instability: persist vcpkg binaries/downloads between jobs.
       - name: Set up binary cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: msvc-full-features/vcpkg_installed
-          key: vcpkg-installed-${{ hashFiles('msvc-full-features/vcpkg.json', '.github/vcpkg_triplets/x64-windows-static.cmake') }}-c3867e714dd3a51c272826eea77267876517ed99
+          key: vcpkg-installed-${{ hashFiles('vcpkg.json', 'vcpkg_overlays/**') }}-c3867e714dd3a51c272826eea77267876517ed99
   
       - name: Linux build
         uses: ./.github/conan_linuxmac_build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,7 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ runner.temp }}/vcpkg-cache
-          key: vcpkg-cache-${{ runner.os }}-${{ hashFiles('**/vcpkg.json', 'vcpkg-overlays/**') }}
+          key: vcpkg-cache-${{ runner.os }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-overlays/**') }}
           restore-keys: |
             vcpkg-cache-${{ runner.os }}-
   
@@ -123,6 +123,9 @@ jobs:
           vcpkgDirectory: ${{ runner.temp }}/vcpkg
         env:
           VCPKG_BINARY_SOURCES: default,rw
+
+      - name: Set vcpkg directory
+        run: echo "VCPKG_LUKKA_DIR=${{ runner.temp }}/vcpkg" >> $GITHUB_ENV
 
       - name: Windows build
         if: startsWith(matrix.os, 'Windows')
@@ -222,7 +225,10 @@ jobs:
           vcpkgDirectory: ${{ runner.temp }}/vcpkg
         env:
           VCPKG_BINARY_SOURCES: default,rw
-          
+        
+        - name: Set vcpkg directory
+        run: echo "VCPKG_LUKKA_DIR=${{ runner.temp }}/vcpkg" >> $GITHUB_ENV
+
       - name: Linux build
         uses: ./.github/conan_linuxmac_build
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,9 @@ on:
   workflow_dispatch:
 
 env:
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Release
+  VCPKG_DIR: ${{ runner.temp }}/vcpkg
+  VCPKG_BINARY_SOURCES: "clear;files,${{ runner.temp }}/vcpkg-cache,readwrite"
+  VCPKG_COMMIT_SHA: c3867e714dd3a51c272826eea77267876517ed99 # corresponds to tag 2026.03.18
 
 # for matrix check https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners
 jobs:
@@ -104,8 +105,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"
-      - name: Configure vcpkg binary caching
-        run: echo "VCPKG_BINARY_SOURCES=clear;files,${{ runner.temp }}/vcpkg-cache,readwrite" >> $GITHUB_ENV
           
       # Workaround for run-vcpkg cache instability: persist vcpkg binaries/downloads between jobs.
       - name: Set up binary cache
@@ -116,23 +115,22 @@ jobs:
           restore-keys: |
             vcpkg-cache-${{ runner.os }}-
   
-      - name: Setup vcpkg
-        uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.6
-        with: 
-          vcpkgGitCommitId: "c3867e714dd3a51c272826eea77267876517ed99" # corresponds to tag 2026.03.18
-          vcpkgDirectory: ${{ runner.temp }}/vcpkg
-        env:
-          VCPKG_BINARY_SOURCES: default,rw
+      - name: Clone vcpkg
+        run: git clone https://github.com/microsoft/vcpkg.git ${{ env.VCPKG_DIR }}
 
-      - name: Set vcpkg directory (Unix)
+      - name: Checkout vcpkg commit
+        working-directory: ${{ env.VCPKG_DIR }}
+        run: git checkout ${{ env.VCPKG_COMMIT_SHA }} # corresponds to tag 2026.03.18
+
+      - name: Bootstrap vcpkg (Unix)
         if: "!startsWith(runner.os, 'Windows')"
-        run: echo "VCPKG_LUKKA_DIR=${{ runner.temp }}/vcpkg" >> $GITHUB_ENV
+        run: ${{ env.VCPKG_DIR }}/bootstrap-vcpkg.sh -disableMetrics
 
-      - name: Set vcpkg directory (Windows)
+      - name: Bootstrap vcpkg (Windows)
         if: startsWith(runner.os, 'Windows')
         shell: pwsh
-        run: echo "VCPKG_LUKKA_DIR=${{ runner.temp }}/vcpkg" >> $env:GITHUB_ENV
-
+        run: ${{ env.VCPKG_DIR }}/bootstrap-vcpkg.bat -disableMetrics.
+  
       - name: Windows build
         if: startsWith(matrix.os, 'Windows')
         uses: ./.github/conan_windows_build
@@ -212,9 +210,6 @@ jobs:
         run: |
           dnf install -y zip
 
-      - name: Configure vcpkg binary caching
-        run: echo "VCPKG_BINARY_SOURCES=clear;files,${{ runner.temp }}/vcpkg-cache,readwrite" >> $GITHUB_ENV
-          
       # Workaround for run-vcpkg cache instability: persist vcpkg binaries/downloads between jobs.
       - name: Set up binary cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -224,17 +219,22 @@ jobs:
           restore-keys: |
             vcpkg-cache-${{ runner.os }}-
 
-      - name: Setup vcpkg
-        uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.6
-        with: 
-          vcpkgGitCommitId: "c3867e714dd3a51c272826eea77267876517ed99" # corresponds to tag 2026.03.18
-          vcpkgDirectory: ${{ runner.temp }}/vcpkg
-        env:
-          VCPKG_BINARY_SOURCES: default,rw
-        
-      - name: Set vcpkg directory
-        run: echo "VCPKG_LUKKA_DIR=${{ runner.temp }}/vcpkg" >> $GITHUB_ENV
+      - name: Clone vcpkg
+        run: git clone https://github.com/microsoft/vcpkg.git ${{ env.VCPKG_DIR }}
 
+      - name: Checkout vcpkg commit
+        working-directory: ${{ env.VCPKG_DIR }}
+        run: git checkout ${{ env.VCPKG_COMMIT_SHA }}
+
+      - name: Bootstrap vcpkg (Unix)
+        if: "!startsWith(runner.os, 'Windows')"
+        run: ${{ env.VCPKG_DIR }}/bootstrap-vcpkg.sh -disableMetrics
+
+      - name: Bootstrap vcpkg (Windows)
+        if: startsWith(runner.os, 'Windows')
+        shell: pwsh
+        run: ${{ env.VCPKG_DIR }}/bootstrap-vcpkg.bat -disableMetrics.
+          
       - name: Linux build
         uses: ./.github/conan_linuxmac_build
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,6 +104,25 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"
+      - name: Configure vcpkg binary caching
+        run: echo "VCPKG_BINARY_SOURCES=clear;files,${{ runner.temp }}/vcpkg-cache,readwrite" >> $GITHUB_ENV
+          
+      # Workaround for run-vcpkg cache instability: persist vcpkg binaries/downloads between jobs.
+      - name: Set up binary cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ runner.temp }}/vcpkg-cache
+          key: vcpkg-cache-${{ runner.os }}-${{ hashFiles('**/vcpkg.json', 'vcpkg-overlays/**') }}
+          restore-keys: |
+            vcpkg-cache-${{ runner.os }}-
+  
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.6
+        with: 
+          vcpkgGitCommitId: "c3867e714dd3a51c272826eea77267876517ed99" # corresponds to tag 2026.03.18
+          vcpkgDirectory: ${{ runner.temp }}/vcpkg
+        env:
+          VCPKG_BINARY_SOURCES: default,rw
 
       - name: Windows build
         if: startsWith(matrix.os, 'Windows')
@@ -192,7 +211,7 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ runner.temp }}/vcpkg-cache
-          key: vcpkg-cache${{ runner.os }}-${{ hashFiles('**/vcpkg.json', 'vcpkg-overlays/**') }}
+          key: vcpkg-cache-${{ runner.os }}-${{ hashFiles('**/vcpkg.json', 'vcpkg-overlays/**') }}
           restore-keys: |
             vcpkg-cache-${{ runner.os }}-
   

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -217,25 +217,23 @@ jobs:
 
       - name: Set vcpkg environment (Unix)
         run: |
-          echo "VCPKG_DIR=${{ github.workspace }}/vcpkg" >> $GITHUB_ENV
-          echo "VCPKG_ROOT=${{ github.workspace }}/vcpkg" >> $GITHUB_ENV
-          echo "VCPKG_BINARY_SOURCES=clear;files,${{ github.workspace }}/vcpkg-cache,readwrite" >> $GITHUB_ENV
+          echo "VCPKG_DIR=${{ runner.temp }}/vcpkg" >> $GITHUB_ENV
+          echo "VCPKG_ROOT=${{ runner.temp }}/vcpkg" >> $GITHUB_ENV
+          echo "VCPKG_BINARY_SOURCES=clear;files,${{ runner.temp }}/vcpkg-cache,readwrite" >> $GITHUB_ENV
 
       - name: Set up binary cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: ${{ github.workspace }}/vcpkg-cache
+          path: ${{ runner.temp }}/vcpkg-cache
           key: vcpkg-cache-${{ runner.os }}-${{ env.VCPKG_COMMIT_SHA }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-overlays/**') }}
           restore-keys: |
             vcpkg-cache-${{ runner.os }}-${{ env.VCPKG_COMMIT_SHA }}
-  
-      - name: Clone and checkout vcpkg
-        run: |
-          git clone https://github.com/microsoft/vcpkg.git --branch master ${{ env.VCPKG_DIR }}
-          git -C ${{ env.VCPKG_DIR }} checkout ${{ env.VCPKG_COMMIT_SHA }}
-
-      - name: Bootstrap vcpkg
-        run: ${{ env.VCPKG_DIR }}/bootstrap-vcpkg.sh -disableMetrics
+    
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.6
+        with:
+          vcpkgGitCommitId: "${{ env.VCPKG_COMMIT_SHA }}"
+          vcpkgDirectory: ${{ runner.temp }}/vcpkg
           
       - name: Linux build
         uses: ./.github/conan_linuxmac_build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,10 +185,20 @@ jobs:
           dnf install -y zip
 
       - name: Setup vcpkg
-        uses: lukka/run-vcpkg@v11
+        uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.6
         with: 
           vcpkgGitCommitId: "c3867e714dd3a51c272826eea77267876517ed99" # corresponds to tag 2026.03.18
           vcpkgDirectory: ${{ runner.temp }}/vcpkg
+        env:
+          VCPKG_BINARY_SOURCES: default,rw
+
+      - name: Set up binary cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
+          key: ${{ runner.os }}-vcpkg-binary-cache-${{ hashFiles('vcpkg*.json') }}
+          restore-keys: |
+            ${{ runner.os }}-vcpkg-binary-cache-
 
       - name: Linux build
         uses: ./.github/conan_linuxmac_build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,7 +182,7 @@ jobs:
   # because the C libs are not compatible with the python versions 
   Python-ManyLinux-2-28-Build:
     runs-on: ubuntu-latest
-    container: quay.io/pypa/manylinux_2_28_x86_64
+    container: quay.io/pypa/manylinux_2_28_x86_64:latest
     strategy:
       matrix:
         include: 
@@ -203,11 +203,12 @@ jobs:
           submodules: recursive
           set-safe-directory: true
 
-      - name: Setup python version
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.11"
-
+      - name: Verify default Python installation
+        run: |
+          python3 --version
+          python3 -m ensurepip --upgrade
+          pip3 --version
+          
       # Ensure zip is available on manylinux before vcpkg setup
       - name: Install zip
         if: contains(matrix.name, 'manylinux')
@@ -248,5 +249,3 @@ jobs:
           build-arch: ${{matrix.build-arch}}
           conan-user: ${{secrets.LKEB_ARTIFACTORY_USER}}
           conan-password: ${{secrets.LKEB_ARTIFACTORY_PASSWORD}}
-        env:
-          VCPKG_BINARY_SOURCES: "clear"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -217,14 +217,14 @@ jobs:
 
       - name: Set vcpkg environment (Unix)
         run: |
-          echo "VCPKG_DIR=${{ runner.temp }}/vcpkg" >> $GITHUB_ENV
-          echo "VCPKG_ROOT=${{ runner.temp }}/vcpkg" >> $GITHUB_ENV
-          echo "VCPKG_BINARY_SOURCES=clear;files,${{ runner.temp }}/vcpkg-cache,readwrite" >> $GITHUB_ENV
+          echo "VCPKG_DIR=${{ github.workspace }}/vcpkg" >> $GITHUB_ENV
+          echo "VCPKG_ROOT=${{ github.workspace }}/vcpkg" >> $GITHUB_ENV
+          echo "VCPKG_BINARY_SOURCES=clear;files,${{ github.workspace }}/vcpkg-cache,readwrite" >> $GITHUB_ENV
 
       - name: Set up binary cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: ${{ runner.temp }}/vcpkg-cache
+          path: ${{ github.workspace }}/vcpkg-cache
           key: vcpkg-cache-${{ runner.os }}-${{ env.VCPKG_COMMIT_SHA }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-overlays/**') }}
           restore-keys: |
             vcpkg-cache-${{ runner.os }}-${{ env.VCPKG_COMMIT_SHA }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
 
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -101,7 +101,7 @@ jobs:
           sudo xcode-select -switch /Applications/Xcode_${{matrix.build-xcode-version}}.app
 
       - name: Setup python version
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -217,7 +217,7 @@ jobs:
           key: vcpkg-cache-${{ runner.os }}-${{ hashFiles('**/vcpkg.json', 'vcpkg-overlays/**') }}
           restore-keys: |
             vcpkg-cache-${{ runner.os }}-
-  
+
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.6
         with: 
@@ -226,7 +226,7 @@ jobs:
         env:
           VCPKG_BINARY_SOURCES: default,rw
         
-        - name: Set vcpkg directory
+      - name: Set vcpkg directory
         run: echo "VCPKG_LUKKA_DIR=${{ runner.temp }}/vcpkg" >> $GITHUB_ENV
 
       - name: Linux build

--- a/conanfile.py
+++ b/conanfile.py
@@ -15,7 +15,6 @@ required_conan_version = "~=1.66.0"
 
 class HDILibConan(ConanFile):
     name = "HDILib"
-    version = "latest"
     description = (
         "HDILib is a library for the scalable analysis of large and high-dimensional"
         " data. "
@@ -142,7 +141,7 @@ class HDILibConan(ConanFile):
         tc = CMakeToolchain(self, generator=generator)
         if self.settings.os == "Windows":
             tc.variables["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = True
-        tc.variables["HDILib_VERSION"] = self.version
+
         if self.build_folder is not None:
             tc.variables["CMAKE_INSTALL_PREFIX"] = str(
                 Path(self.build_folder, "install").as_posix()
@@ -156,8 +155,7 @@ class HDILibConan(ConanFile):
             proc = subprocess.run(
                 "brew --prefix libomp", shell=True, capture_output=True
             )
-            omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
-            tc.variables["OpenMP_ROOT"] = omp_prefix_path
+            tc.variables["OpenMP_ROOT"] = f"{proc.stdout.decode('UTF-8').strip()}"
 
         tc.cache_variables["HDILib_BUILD_EXAMPLE"] = True
 
@@ -167,7 +165,6 @@ class HDILibConan(ConanFile):
 
     def _configure_cmake(self):
         cmake = CMake(self)
-        print(f"Set version to {self.version}")
         cmake.configure()
         return cmake
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -88,11 +88,11 @@ class HDILibConan(ConanFile):
         return f"{arch}-linux"  # T.B.D. macos
 
     def _get_vcpkg_root(self):
-        vcpkg_root = os.getenv("VCPKG_INSTALLATION_ROOT", None)
+        vcpkg_root = os.getenv("VCPKG_LUKKA_DIR", None)  # VCPKG_INSTALLATION_ROOT is the default vcpkg on github ci runners
         if vcpkg_root is None:
             raise RuntimeError(
                 "Expected a preinstalled vcpkg and the environment variable"
-                " VCPKG_INSTALLATION_ROOT to be available"
+                " VCPKG_LUKKA_DIR to be available"
             )
         return vcpkg_root
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -62,7 +62,7 @@ class HDILibConan(ConanFile):
         return "cmake"
 
     def requirements(self): 
-        self.requires.add("flann/1.9.2@lkeb/%s" % self.channel)
+        pass # handled via vcpkg
 
     def system_requirements(self):
         if os_info.is_macos:
@@ -149,23 +149,8 @@ class HDILibConan(ConanFile):
             )
         else:
             tc.variables["CMAKE_INSTALL_PREFIX"] = "${CMAKE_BINARY_DIR}"
+        
         tc.variables["CMAKE_VERBOSE_MAKEFILE"] = "ON"
-        if os.getenv("Analysis", None) is None:
-            tc.variables["HDILib_ENABLE_CODE_ANALYSIS"] = "OFF"
-        else:
-            tc.variables["HDILib_ENABLE_CODE_ANALYSIS"] = "ON"
-        tc.variables["CMAKE_MSVC_RUNTIME_LIBRARY"] = (
-            "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL"
-        )
-        # Use the cmake export in the flann package
-        tc.variables["flann_ROOT"] = Path(
-            self.deps_cpp_info["flann"].rootpath, "lib", "cmake"
-        ).as_posix()
-        # Use the cmake export in the lz4 package
-        tc.variables["lz4_ROOT"] = Path(
-            self.deps_cpp_info["lz4"].rootpath, "lib", "cmake"
-        ).as_posix()
-        tc.variables["IN_CONAN_BUILD"] = "TRUE"
 
         if os_info.is_macos:
             proc = subprocess.run(

--- a/conanfile.py
+++ b/conanfile.py
@@ -187,7 +187,7 @@ class HDILibConan(ConanFile):
         cmake_release.build(build_type="Release")
         cmake_release.install(build_type="Release")
 
-        print(f"Conan: Build RelWithDebInfo")
+        #print(f"Conan: Build RelWithDebInfo")
         #cmake_release = self._configure_cmake()
         #cmake_release.build(build_type="RelWithDebInfo")
         #cmake_release.install(build_type="RelWithDebInfo")

--- a/conanfile.py
+++ b/conanfile.py
@@ -131,7 +131,7 @@ class HDILibConan(ConanFile):
             json.dump(conan_preset_data, f, indent=2)
 
     def generate(self):
-        print("In generate")
+        print("Conan: generate CMake toolchain")
         generator = None
         if self.settings.os == "Macos":
             generator = "Xcode"
@@ -161,7 +161,6 @@ class HDILibConan(ConanFile):
 
         tc.cache_variables["HDILib_BUILD_EXAMPLE"] = True
 
-        print("Call toolchain generate")
         tc.generate()
         self._inject_vcpkg_in_cmake_presets()
 
@@ -178,19 +177,20 @@ class HDILibConan(ConanFile):
         install_dir = Path(self.build_folder).joinpath("install")
         install_dir.mkdir(exist_ok=True)
 
-        #cmake_debug = self._configure_cmake()
-        #cmake_debug.build(build_type="Debug")
-        #cmake_debug.install(build_type="Debug")
+        print(f"Conan: Build Debug")
+        cmake_debug = self._configure_cmake()
+        cmake_debug.build(build_type="Debug")
+        cmake_debug.install(build_type="Debug")
 
-        if os.getenv("Analysis", None) is None:
-            # Disable code analysis in Release mode
-            cmake_release = self._configure_cmake()
-            cmake_release.build(build_type="Release")
-            cmake_release.install(build_type="Release")
+        print(f"Conan: Build Release")
+        cmake_release = self._configure_cmake()
+        cmake_release.build(build_type="Release")
+        cmake_release.install(build_type="Release")
 
-            #cmake_release = self._configure_cmake()
-            #cmake_release.build(build_type="RelWithDebInfo")
-            #cmake_release.install(build_type="RelWithDebInfo")
+        print(f"Conan: Build RelWithDebInfo")
+        #cmake_release = self._configure_cmake()
+        #cmake_release.build(build_type="RelWithDebInfo")
+        #cmake_release.install(build_type="RelWithDebInfo")
 
     def package_id(self):
         # The package contains both Debug and Release build types

--- a/conanfile.py
+++ b/conanfile.py
@@ -87,11 +87,11 @@ class HDILibConan(ConanFile):
         return f"{arch}-linux"  # T.B.D. macos
 
     def _get_vcpkg_root(self):
-        vcpkg_root = os.getenv("VCPKG_LUKKA_DIR", None)  # VCPKG_INSTALLATION_ROOT is the default vcpkg on github ci runners
+        vcpkg_root = os.getenv("VCPKG_DIR", None)  # VCPKG_INSTALLATION_ROOT is the default vcpkg on github ci runners
         if vcpkg_root is None:
             raise RuntimeError(
                 "Expected a preinstalled vcpkg and the environment variable"
-                " VCPKG_LUKKA_DIR to be available"
+                " VCPKG_DIR to be available"
             )
         return vcpkg_root
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -177,10 +177,10 @@ class HDILibConan(ConanFile):
         install_dir = Path(self.build_folder).joinpath("install")
         install_dir.mkdir(exist_ok=True)
 
-        print(f"Conan: Build Debug")
-        cmake_debug = self._configure_cmake()
-        cmake_debug.build(build_type="Debug")
-        cmake_debug.install(build_type="Debug")
+        #print(f"Conan: Build Debug")
+        #cmake_debug = self._configure_cmake()
+        #cmake_debug.build(build_type="Debug")
+        #cmake_debug.install(build_type="Debug")
 
         print(f"Conan: Build Release")
         cmake_release = self._configure_cmake()

--- a/conanfile.py
+++ b/conanfile.py
@@ -88,6 +88,7 @@ class HDILibConan(ConanFile):
 
     def _get_vcpkg_root(self):
         vcpkg_root = os.getenv("VCPKG_DIR", None)  # VCPKG_INSTALLATION_ROOT is the default vcpkg on github ci runners
+        print(f"Conan: vcpkg_root is {vcpkg_root}")
         if vcpkg_root is None:
             raise RuntimeError(
                 "Expected a preinstalled vcpkg and the environment variable"
@@ -100,6 +101,7 @@ class HDILibConan(ConanFile):
         vcpkg_tc_path = Path(
             self._get_vcpkg_root(), "scripts", "buildsystems", "vcpkg.cmake"
         )
+        print(f"Conan: vcpkg_tc_path is {vcpkg_tc_path}")
         if not vcpkg_tc_path.exists():
             raise RuntimeError(
                 f"Expected vcpkg toolchain not found at {vcpkg_tc_path.absolute()}"


### PR DESCRIPTION
- Add binary cache setup for vcpkg with actions/cache
- Update and use specific commit for some actions
- Use lukka/run-vcpkg only in manilinux container to handle container-path automatically
- Do not download vcpkg-handled dependencies (lz4, flann) from artifactory
- ~~Build both debug and release again on ci~~ (not yet possible due to broken CMake config, see #70)