### PR TITLE
Fix caching for some runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,27 +214,29 @@ jobs:
         if: contains(matrix.name, 'manylinux')
         run: |
           dnf install -y zip
-
+      
       - name: Set vcpkg environment (Unix)
         run: |
-          echo "VCPKG_DIR=${{ runner.temp }}/vcpkg" >> $GITHUB_ENV
-          echo "VCPKG_ROOT=${{ runner.temp }}/vcpkg" >> $GITHUB_ENV
-          echo "VCPKG_BINARY_SOURCES=clear;files,${{ runner.temp }}/vcpkg-cache,readwrite" >> $GITHUB_ENV
-   
-      - name: Setup vcpkg
-        uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.6
-        with:
-          vcpkgGitCommitId: "${{ env.VCPKG_COMMIT_SHA }}"
-          vcpkgDirectory: ${{ runner.temp }}/vcpkg
-
+          echo "VCPKG_DIR=/opt/vcpkg" >> $GITHUB_ENV
+          echo "VCPKG_ROOT=/opt/vcpkg" >> $GITHUB_ENV
+          echo "VCPKG_BINARY_SOURCES=clear;files,/opt/vcpkg-cache,readwrite" >> $GITHUB_ENV
+      
       - name: Set up binary cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
-          path: ${{ runner.temp }}/vcpkg-cache
-          key: vcpkg-cache-manylinux-2-28-${{ runner.os }}-${{ env.VCPKG_COMMIT_SHA }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-overlays/**') }}
+          path: /opt/vcpkg-cache
+          key: vcpkg-cache-manylinux-2-28-${{ env.VCPKG_COMMIT_SHA }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-overlays/**') }}
           restore-keys: |
-            vcpkg-cache-manylinux-2-28-${{ runner.os }}-${{ env.VCPKG_COMMIT_SHA }}
-          
+            vcpkg-cache-manylinux-2-28-${{ env.VCPKG_COMMIT_SHA }}
+      
+      - name: Clone and checkout vcpkg
+        run: |
+          git clone https://github.com/microsoft/vcpkg.git --branch master /opt/vcpkg
+          git -C /opt/vcpkg checkout ${{ env.VCPKG_COMMIT_SHA }}
+      
+      - name: Bootstrap vcpkg
+        run: /opt/vcpkg/bootstrap-vcpkg.sh -disableMetrics
+  
       - name: Linux build
         uses: ./.github/conan_linuxmac_build
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -220,6 +220,12 @@ jobs:
           echo "VCPKG_DIR=${{ runner.temp }}/vcpkg" >> $GITHUB_ENV
           echo "VCPKG_ROOT=${{ runner.temp }}/vcpkg" >> $GITHUB_ENV
           echo "VCPKG_BINARY_SOURCES=clear;files,${{ runner.temp }}/vcpkg-cache,readwrite" >> $GITHUB_ENV
+   
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.6
+        with:
+          vcpkgGitCommitId: "${{ env.VCPKG_COMMIT_SHA }}"
+          vcpkgDirectory: ${{ runner.temp }}/vcpkg
 
       - name: Set up binary cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -228,12 +234,6 @@ jobs:
           key: vcpkg-cache-manylinux-2-28-${{ runner.os }}-${{ env.VCPKG_COMMIT_SHA }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-overlays/**') }}
           restore-keys: |
             vcpkg-cache-manylinux-2-28-${{ runner.os }}-${{ env.VCPKG_COMMIT_SHA }}
-    
-      - name: Setup vcpkg
-        uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.6
-        with:
-          vcpkgGitCommitId: "${{ env.VCPKG_COMMIT_SHA }}"
-          vcpkgDirectory: ${{ runner.temp }}/vcpkg
           
       - name: Linux build
         uses: ./.github/conan_linuxmac_build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,9 +123,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ runner.temp }}/vcpkg-cache
-          key: vcpkg-cache-${{ runner.os }}-${{ env.VCPKG_COMMIT_SHA }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-overlays/**') }}
+          key: vcpkg-cache-${{ runner.os }}-${{ matrix.os }}-${{ matrix.build-cversion }}-${{ env.VCPKG_COMMIT_SHA }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-overlays/**') }}
           restore-keys: |
-            vcpkg-cache-${{ runner.os }}-${{ env.VCPKG_COMMIT_SHA }}
+            vcpkg-cache-${{ runner.os }}-${{ matrix.os }}-${{ matrix.build-cversion }}-${{ env.VCPKG_COMMIT_SHA }}
   
       - name: Clone and checkout vcpkg
         run: |
@@ -225,9 +225,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ runner.temp }}/vcpkg-cache
-          key: vcpkg-cache-${{ runner.os }}-${{ env.VCPKG_COMMIT_SHA }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-overlays/**') }}
+          key: vcpkg-cache-manylinux-2-28-${{ runner.os }}-${{ env.VCPKG_COMMIT_SHA }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-overlays/**') }}
           restore-keys: |
-            vcpkg-cache-${{ runner.os }}-${{ env.VCPKG_COMMIT_SHA }}
+            vcpkg-cache-manylinux-2-28-${{ runner.os }}-${{ env.VCPKG_COMMIT_SHA }}
     
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.6


### PR DESCRIPTION
The cache is not being effectively used in the Macos_xcode16 and Python-ManyLinux-2-28-Build jobs due to mismatched cache key components and container-related differences in how path variables are handled.

### For Macos_xcode16
The issue is in the cache key construction:
```yaml
key: vcpkg-cache-${{ runner.os }}-${{ env.VCPKG_COMMIT_SHA }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-overlays/**') }}
```

The macOS-15 runner (used by Macos_xcode16) differs from macOS-14 runners. The problem is that:
- Xcode 14.3, 15 use macos-14
- Xcode 16 uses macos-15

While runner.os is macOS for both, the underlying system libraries and tools differ significantly between macOS 14 and 15. This means the vcpkg cache built on macOS 14 is incompatible with macOS 15, but the key doesn't account for this OS version difference—only runner.os (which is generic "macOS").

### For Python-ManyLinux-2-28-Build
Containers have a specific quirk that breaks the standard approach: `runner.temp` is not guaranteed to be set or accessible inside a container job.
In a regular runner job, `runner.temp` resolves to something like `/home/runner/work/_temp`. But inside a Docker container, the GitHub Actions context variables like `runner.temp` may be empty or point to a path that doesn't exist within the container's filesystem.

## Solutions
1. Include OS and compiler version in Cache Key (For Macos_xcode16)
2. Use hard-coded absolute paths (`/opt/vcpkg`, `/opt/vcpkg-cache`) and do not use `lukka/run-vcpkg` (For Python-ManyLinux Job)

---

Thanks, Claude 🤖